### PR TITLE
Feature/update with c4 plant uml v220

### DIFF
--- a/Structurizr.ActiveDirectory/Structurizr.ActiveDirectory.csproj
+++ b/Structurizr.ActiveDirectory/Structurizr.ActiveDirectory.csproj
@@ -8,12 +8,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.16.1" />
-    <PackageReference Include="Structurizr.Client" Version="0.9.6" />
+    <PackageReference Include="Structurizr.Client" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Structurizr.AdrTools.Tests/AdrTools/AdrToolsImporterTests.cs
+++ b/Structurizr.AdrTools.Tests/AdrTools/AdrToolsImporterTests.cs
@@ -106,7 +106,8 @@ namespace Structurizr.AdrTools.Tests
             importer.ImportArchitectureDecisionRecords();
 
             Decision decision5 = _documentation.Decisions.Where(d => d.Id == "5").First();
-            Assert.True(decision5.Content.Contains("Amended by [9. Help scripts](#/:9)"));
+            // sync with java impl %2F instead of /
+            Assert.True(decision5.Content.Contains("Amended by [9. Help scripts](#%2F:9)"));
         }
 
         [Fact]
@@ -127,7 +128,8 @@ namespace Structurizr.AdrTools.Tests
 
             Decision decision4 = _documentation.Decisions.Where(d => d.Id == "4").First();
             Assert.Equal(DecisionStatus.Superseded, decision4.Status);
-            Assert.True(decision4.Content.Contains("Superceded by [10. AsciiDoc format](#/:10)"));
+            // sync with java impl %2F instead of /
+            Assert.True(decision4.Content.Contains("Superceded by [10. AsciiDoc format](#%2F:10)"));
         }
 
     }

--- a/Structurizr.AdrTools.Tests/Structurizr.AdrTools.Tests.csproj
+++ b/Structurizr.AdrTools.Tests/Structurizr.AdrTools.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/Structurizr.AdrTools/AdrTools/AdrToolsImporter.cs
+++ b/Structurizr.AdrTools/AdrTools/AdrToolsImporter.cs
@@ -90,11 +90,15 @@ namespace Structurizr.AdrTools
         private string CalculateUrl(SoftwareSystem softwareSystem, string id)
         {
             if (softwareSystem == null) {
-                return "#/:" + UrlEncode(id);
+                // sync with java impl
+                return "#" + UrlEncode("/") + ":" + UrlEncode(id);
             }
             else
             {
-                return "#" + UrlEncode(softwareSystem.CanonicalName) + ":" + UrlEncode(id);
+                //CanonicalName impl changed: old "/", new "SoftwareSystem://" (CanonicalNameGenerator.SoftwareSystemType)
+                var name = softwareSystem.CanonicalName;
+                name = name.Substring("SoftwareSystem:/".Length); // last "/" is reused
+                return "#" + UrlEncode(name) + ":" + UrlEncode(id);
             }
         }
 

--- a/Structurizr.AdrTools/Structurizr.AdrTools.csproj
+++ b/Structurizr.AdrTools/Structurizr.AdrTools.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Structurizr.Core" Version="0.9.6" />
+    <PackageReference Include="Structurizr.Core" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Structurizr.Analysis/Structurizr.Analysis.csproj
+++ b/Structurizr.Analysis/Structurizr.Analysis.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Structurizr.Core" Version="0.9.6" />
+    <PackageReference Include="Structurizr.Core" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Structurizr.Annotations/Structurizr.Annotations.csproj
+++ b/Structurizr.Annotations/Structurizr.Annotations.csproj
@@ -17,7 +17,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
+<!--
     <TargetFrameworks>netstandard1.0;net20;portable40-net40+sl4+win8+wp7;portable40-net40+sl5+win8+wp8+wpa81</TargetFrameworks>
+
+    <TargetFrameworks>netstandard1.0;netstandard2.0;net20;portable40-net40+sl4+win8+wp7;portable40-net40+sl5+win8+wp8+wpa81</TargetFrameworks>
+-->
+    <TargetFrameworks>netstandard2.0;net20</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Structurizr.Annotations.xml</DocumentationFile>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
@@ -48,4 +53,11 @@
       <Version>4.1.0</Version>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Runtime">
+      <Version>4.1.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/Structurizr.Cecil.Examples/Structurizr.Cecil.Examples.csproj
+++ b/Structurizr.Cecil.Examples/Structurizr.Cecil.Examples.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.10.0" />
-    <PackageReference Include="Structurizr.Client" Version="0.9.3" />
+    <PackageReference Include="Structurizr.Client" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Structurizr.Cecil/Structurizr.Cecil.csproj
+++ b/Structurizr.Cecil/Structurizr.Cecil.csproj
@@ -16,12 +16,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.10.0" />
-    <PackageReference Include="Structurizr.Core" Version="0.9.6" />
+    <PackageReference Include="Structurizr.Core" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Structurizr.Examples/Structurizr.Examples.csproj
+++ b/Structurizr.Examples/Structurizr.Examples.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <StartupObject>Structurizr.Examples.PlantUML</StartupObject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Structurizr.Client" Version="0.9.6" />
+    <PackageReference Include="Structurizr.Client" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Structurizr.AdrTools\Structurizr.AdrTools.csproj" />

--- a/Structurizr.PlantUML.Tests/IO/C4PlantUML/C4PlantUmlWriterTests.cs
+++ b/Structurizr.PlantUML.Tests/IO/C4PlantUML/C4PlantUmlWriterTests.cs
@@ -383,23 +383,23 @@ endlegend
 !define Node(e_alias, e_label, e_techn) rectangle ""==e_label\n<size:TECHN_FONT_SIZE>[e_techn]</size>"" <<node>> as e_alias
 
 ' Structurizr.DeploymentView: DevelopmentDeployment
-title Internet Banking System - Deployment
+title Internet Banking System - Deployment - Development
 
 LAYOUT_WITH_LEGEND()
 
-Node(Deployment__Development__DeveloperLaptop__389f399, ""Developer Laptop"", ""Microsoft Windows 10 or Apple </size>\n<size:TECHN_FONT_SIZE>macOS"") {
-  Node(Deployment__Development__DeveloperLaptop__DockerContainerWebServer__1b73d2e, ""Docker Container - Web Server"", ""Docker"") {
-    Node(Deployment__Development__DeveloperLaptop__DockerContainerWebServer__ApacheTomcat__1cc9f55, ""Apache Tomcat"", ""Apache Tomcat 8.x"") {
+Node(DeveloperLaptop__389f399, ""Developer Laptop"", ""Microsoft Windows 10 or Apple </size>\n<size:TECHN_FONT_SIZE>macOS"") {
+  Node(DockerContainerWebServer__1b73d2e, ""Docker Container - Web Server"", ""Docker"") {
+    Node(ApacheTomcat__1cc9f55, ""Apache Tomcat"", ""Apache Tomcat 8.x"") {
       Container(InternetBankingSystem__WebApplication1__28f79f6, ""Web Application"", ""Java and Spring MVC"", ""Delivers the static content and the Internet banking single page application."")
       Container(InternetBankingSystem__APIApplication1__1f227f4, ""API Application"", ""Java and Spring MVC"", ""Provides Internet banking functionality via a JSON/HTTPS API."")
     }
   }
-  Node(Deployment__Development__DeveloperLaptop__DockerContainerDatabaseServer__2eae566, ""Docker Container - Database Server"", ""Docker"") {
-    Node(Deployment__Development__DeveloperLaptop__DockerContainerDatabaseServer__DatabaseServer__24d13de, ""Database Server"", ""Oracle 12c"") {
+  Node(DockerContainerDatabaseServer__2eae566, ""Docker Container - Database Server"", ""Docker"") {
+    Node(DatabaseServer__24d13de, ""Database Server"", ""Oracle 12c"") {
       ContainerDb(InternetBankingSystem__Database1__3296ca6, ""Database"", ""Relational Database Schema"", ""Stores user registration information, hashed authentication credentials, access logs, etc."")
     }
   }
-  Node(Deployment__Development__DeveloperLaptop__WebBrowser__3930fd, ""Web Browser"", ""Google Chrome, Mozilla </size>\n<size:TECHN_FONT_SIZE>Firefox, Apple Safari or </size>\n<size:TECHN_FONT_SIZE>Microsoft Edge"") {
+  Node(WebBrowser__3930fd, ""Web Browser"", ""Google Chrome, Mozilla </size>\n<size:TECHN_FONT_SIZE>Firefox, Apple Safari or </size>\n<size:TECHN_FONT_SIZE>Microsoft Edge"") {
     Container(InternetBankingSystem__SinglePageApplication1__bbe85d, ""Single-Page Application"", ""JavaScript and Angular"", ""Provides all of the Internet banking functionality to customers via their web browser."")
   }
 }
@@ -450,46 +450,46 @@ endlegend
 !define Node(e_alias, e_label, e_techn) rectangle ""==e_label\n<size:TECHN_FONT_SIZE>[e_techn]</size>"" <<node>> as e_alias
 
 ' Structurizr.DeploymentView: LiveDeployment
-title Internet Banking System - Deployment
+title Internet Banking System - Deployment - Live
 
 LAYOUT_WITH_LEGEND()
 
-Node(Deployment__Live__BigBankplc__3ffe15e, ""Big Bank plc"", ""Big Bank plc data center"") {
-  Node(Deployment__Live__BigBankplc__bigbankweb***__3f92e18, ""bigbank-web*** (x4)"", ""Ubuntu 16.04 LTS"") {
-    Node(Deployment__Live__BigBankplc__bigbankweb***__ApacheTomcat__27b4383, ""Apache Tomcat"", ""Apache Tomcat 8.x"") {
-      Container(InternetBankingSystem__WebApplication2__1720850, ""Web Application"", ""Java and Spring MVC"", ""Delivers the static content and the Internet banking single page application."")
+Node(BigBankplc__3ffe15e, ""Big Bank plc"", ""Big Bank plc data center"") {
+  Node(bigbankweb***__3f92e18, ""bigbank-web*** (x4)"", ""Ubuntu 16.04 LTS"") {
+    Node(ApacheTomcat__27b4383, ""Apache Tomcat"", ""Apache Tomcat 8.x"") {
+      Container(InternetBankingSystem__WebApplication1__1720850, ""Web Application"", ""Java and Spring MVC"", ""Delivers the static content and the Internet banking single page application."")
     }
   }
-  Node(Deployment__Live__BigBankplc__bigbankapi***__263d9e8, ""bigbank-api*** (x8)"", ""Ubuntu 16.04 LTS"") {
-    Node(Deployment__Live__BigBankplc__bigbankapi***__ApacheTomcat__3b84ab, ""Apache Tomcat"", ""Apache Tomcat 8.x"") {
-      Container(InternetBankingSystem__APIApplication2__1408a33, ""API Application"", ""Java and Spring MVC"", ""Provides Internet banking functionality via a JSON/HTTPS API."")
+  Node(bigbankapi***__263d9e8, ""bigbank-api*** (x8)"", ""Ubuntu 16.04 LTS"") {
+    Node(ApacheTomcat__3b84ab, ""Apache Tomcat"", ""Apache Tomcat 8.x"") {
+      Container(InternetBankingSystem__APIApplication1__1408a33, ""API Application"", ""Java and Spring MVC"", ""Provides Internet banking functionality via a JSON/HTTPS API."")
     }
   }
-  Node(Deployment__Live__BigBankplc__bigbankdb01__35ec592, ""bigbank-db01"", ""Ubuntu 16.04 LTS"") {
-    Node(Deployment__Live__BigBankplc__bigbankdb01__OraclePrimary__19fd8f, ""Oracle - Primary"", ""Oracle 12c"") {
-      ContainerDb(InternetBankingSystem__Database2__1c974ec, ""Database"", ""Relational Database Schema"", ""Stores user registration information, hashed authentication credentials, access logs, etc."")
+  Node(bigbankdb01__35ec592, ""bigbank-db01"", ""Ubuntu 16.04 LTS"") {
+    Node(OraclePrimary__19fd8f, ""Oracle - Primary"", ""Oracle 12c"") {
+      ContainerDb(InternetBankingSystem__Database1__1c974ec, ""Database"", ""Relational Database Schema"", ""Stores user registration information, hashed authentication credentials, access logs, etc."")
     }
   }
-  Node(Deployment__Live__BigBankplc__bigbankdb02__1db08a2, ""bigbank-db02"", ""Ubuntu 16.04 LTS"") {
-    Node(Deployment__Live__BigBankplc__bigbankdb02__OracleSecondary__1c4ec22, ""Oracle - Secondary"", ""Oracle 12c"") {
-      ContainerDb(InternetBankingSystem__Database3__d89394, ""Database"", ""Relational Database Schema"", ""Stores user registration information, hashed authentication credentials, access logs, etc."")
+  Node(bigbankdb02__1db08a2, ""bigbank-db02"", ""Ubuntu 16.04 LTS"") {
+    Node(OracleSecondary__1c4ec22, ""Oracle - Secondary"", ""Oracle 12c"") {
+      ContainerDb(InternetBankingSystem__Database1__d89394, ""Database"", ""Relational Database Schema"", ""Stores user registration information, hashed authentication credentials, access logs, etc."")
     }
   }
 }
-Node(Deployment__Live__Customer'scomputer__2510bf3, ""Customer's computer"", ""Microsoft Windows or Apple </size>\n<size:TECHN_FONT_SIZE>macOS"") {
-  Node(Deployment__Live__Customer'scomputer__WebBrowser__ba951, ""Web Browser"", ""Google Chrome, Mozilla </size>\n<size:TECHN_FONT_SIZE>Firefox, Apple Safari or </size>\n<size:TECHN_FONT_SIZE>Microsoft Edge"") {
-    Container(InternetBankingSystem__SinglePageApplication2__298b31c, ""Single-Page Application"", ""JavaScript and Angular"", ""Provides all of the Internet banking functionality to customers via their web browser."")
+Node(Customer'scomputer__2510bf3, ""Customer's computer"", ""Microsoft Windows or Apple </size>\n<size:TECHN_FONT_SIZE>macOS"") {
+  Node(WebBrowser__ba951, ""Web Browser"", ""Google Chrome, Mozilla </size>\n<size:TECHN_FONT_SIZE>Firefox, Apple Safari or </size>\n<size:TECHN_FONT_SIZE>Microsoft Edge"") {
+    Container(InternetBankingSystem__SinglePageApplication1__298b31c, ""Single-Page Application"", ""JavaScript and Angular"", ""Provides all of the Internet banking functionality to customers via their web browser."")
   }
 }
-Node(Deployment__Live__Customer'smobiledevice__1d6bcb6, ""Customer's mobile device"", ""Apple iOS or Android"") {
+Node(Customer'smobiledevice__1d6bcb6, ""Customer's mobile device"", ""Apple iOS or Android"") {
   Container(InternetBankingSystem__MobileApp1__d004b3, ""Mobile App"", ""Xamarin"", ""Provides a limited subset of the Internet banking functionality to customers via their mobile device."")
 }
-Rel(InternetBankingSystem__APIApplication2__1408a33, InternetBankingSystem__Database2__1c974ec, ""Reads from and writes to"", ""JDBC"")
-Rel(InternetBankingSystem__APIApplication2__1408a33, InternetBankingSystem__Database3__d89394, ""Reads from and writes to"", ""JDBC"")
-Rel(InternetBankingSystem__MobileApp1__d004b3, InternetBankingSystem__APIApplication2__1408a33, ""Makes API calls to"", ""JSON/HTTPS"")
-Rel(InternetBankingSystem__SinglePageApplication2__298b31c, InternetBankingSystem__APIApplication2__1408a33, ""Makes API calls to"", ""JSON/HTTPS"")
-Rel_Up(InternetBankingSystem__WebApplication2__1720850, InternetBankingSystem__SinglePageApplication2__298b31c, ""Delivers to the customer's web browser"")
-Rel_Left(Deployment__Live__BigBankplc__bigbankdb01__OraclePrimary__19fd8f, Deployment__Live__BigBankplc__bigbankdb02__OracleSecondary__1c4ec22, ""Replicates data to"")
+Rel(InternetBankingSystem__APIApplication1__1408a33, InternetBankingSystem__Database1__1c974ec, ""Reads from and writes to"", ""JDBC"")
+Rel(InternetBankingSystem__APIApplication1__1408a33, InternetBankingSystem__Database1__d89394, ""Reads from and writes to"", ""JDBC"")
+Rel(InternetBankingSystem__MobileApp1__d004b3, InternetBankingSystem__APIApplication1__1408a33, ""Makes API calls to"", ""JSON/HTTPS"")
+Rel_Left(OraclePrimary__19fd8f, OracleSecondary__1c4ec22, ""Replicates data to"")
+Rel(InternetBankingSystem__SinglePageApplication1__298b31c, InternetBankingSystem__APIApplication1__1408a33, ""Makes API calls to"", ""JSON/HTTPS"")
+Rel_Up(InternetBankingSystem__WebApplication1__1720850, InternetBankingSystem__SinglePageApplication1__298b31c, ""Delivers to the customer's web browser"")
 @enduml
 
 ".UnifyNewLine().UnifyHashValues(), _stringWriter.ToString().UnifyHashValues());
@@ -504,9 +504,9 @@ Rel_Left(Deployment__Live__BigBankplc__bigbankdb01__OraclePrimary__19fd8f, Deplo
             // all SystemLandscapeView, SystemContext, ... (update relation): 
             //     Rel_Up(EmailSystem, PersonalBankingCustomer, ""Sends e-mails to"")
             //     Rel_Right(InternetBankingSystem, EmailSystem, ""Sends e-mail using"")
-            var emailSystem = workspace.Model.GetElementWithCanonicalName("/E-mail System");
-            var personalBankingCustomer = workspace.Model.GetElementWithCanonicalName("/Personal Banking Customer");
-            var internetBankingSystem = workspace.Model.GetElementWithCanonicalName("/Internet Banking System");
+            var emailSystem = workspace.Model.GetElementWithCanonicalOrStaticalName("SoftwareSystem://E-mail System");
+            var personalBankingCustomer = workspace.Model.GetElementWithCanonicalOrStaticalName("Person://Personal Banking Customer");
+            var internetBankingSystem = workspace.Model.GetElementWithCanonicalOrStaticalName("SoftwareSystem://Internet Banking System");
 
             var systemLandscapeView = workspace.Views.SystemLandscapeViews.First();
             systemLandscapeView.Relationships
@@ -519,7 +519,7 @@ Rel_Left(Deployment__Live__BigBankplc__bigbankdb01__OraclePrimary__19fd8f, Deplo
                 .SetDirection(DirectionValues.Right);
 
             // but only SystemLandscapeView should use Down relations, therefore add the tags relation view specific (via AddViewTags)
-            var mainframeBankingSystem = workspace.Model.GetElementWithCanonicalName("/Mainframe Banking System");
+            var mainframeBankingSystem = workspace.Model.GetElementWithCanonicalOrStaticalName("SoftwareSystem://Mainframe Banking System");
             foreach (var relationshipView in systemLandscapeView.Relationships
                 .Where(rv => rv.Relationship.DestinationId == mainframeBankingSystem.Id))
             {
@@ -537,12 +537,12 @@ Rel_Left(Deployment__Live__BigBankplc__bigbankdb01__OraclePrimary__19fd8f, Deplo
             //     Rel_Right(InternetBankingSystem__SinglePageApplication, InternetBankingSystem__APIApplication__SignInController, ...)
             //     Rel_Right(InternetBankingSystem__APIApplication__SecurityComponent, InternetBankingSystem__Database, ...)
             var singlePageApplication =
-                workspace.Model.GetElementWithCanonicalName("/Internet Banking System/Single-Page Application");
+                workspace.Model.GetElementWithCanonicalOrStaticalName("Container://Internet Banking System.Single-Page Application");
             var signInController =
-                workspace.Model.GetElementWithCanonicalName("/Internet Banking System/API Application/Sign In Controller");
+                workspace.Model.GetElementWithCanonicalOrStaticalName("Component://Internet Banking System.API Application.Sign In Controller");
             var securityComponent =
-                workspace.Model.GetElementWithCanonicalName("/Internet Banking System/API Application/Security Component");
-            var database = workspace.Model.GetElementWithCanonicalName("/Internet Banking System/Database") as Container;
+                workspace.Model.GetElementWithCanonicalOrStaticalName("Component://Internet Banking System.API Application.Security Component");
+            var database = workspace.Model.GetElementWithCanonicalOrStaticalName("Container://Internet Banking System.Database") as Container;
             database.SetIsDatabase(true);
             var dynamicView = workspace.Views.DynamicViews.First();
             dynamicView.Relationships
@@ -555,10 +555,8 @@ Rel_Left(Deployment__Live__BigBankplc__bigbankdb01__OraclePrimary__19fd8f, Deplo
 
             // ContainerView
             //     Rel_Up(InternetBankingSystem__WebApplication, InternetBankingSystem__SinglePageApplication, "Delivers to the customer's web browser")
-            var apiApplication = workspace.Model.GetElementWithCanonicalName("/Internet Banking System/API Application");
-            var webApplication = workspace.Model.GetElementWithCanonicalName("/Internet Banking System/Web Application");
-
-
+            var apiApplication = workspace.Model.GetElementWithCanonicalOrStaticalName("Container://Internet Banking System.API Application");
+            var webApplication = workspace.Model.GetElementWithCanonicalOrStaticalName("Container://Internet Banking System.Web Application");
             var containerView = workspace.Views.ContainerViews.First();
             containerView.Relationships
                 .First(r => r.Relationship.SourceId == apiApplication.Id &&
@@ -584,29 +582,34 @@ Rel_Left(Deployment__Live__BigBankplc__bigbankdb01__OraclePrimary__19fd8f, Deplo
             // DeploymentView´(with already copied relations): DevelopmentDeployment, LiveDeployment
             //     Rel_Up(InternetBankingSystem__WebApplication1, InternetBankingSystem__SinglePageApplication1, "Delivers to the customer's web browser") 
             //     Rel_Up(InternetBankingSystem__WebApplication2, InternetBankingSystem__SinglePageApplication2, "Delivers to the customer's web browser")
-            //     Rel_Left(Deployment__Live__BigBankplc__bigbankdb01__OraclePrimary, Deployment__Live__BigBankplc__bigbankdb02__OracleSecondary, "Replicates data to")
-            var webApplication1 = workspace.Model.GetElementWithCanonicalName("/Internet Banking System/Web Application[1]");
-            var webApplication2 = workspace.Model.GetElementWithCanonicalName("/Internet Banking System/Web Application[2]");
-            var singlePageApplication1 =
-                workspace.Model.GetElementWithCanonicalName("/Internet Banking System/Single-Page Application[1]");
-            var singlePageApplication2 =
-                workspace.Model.GetElementWithCanonicalName("/Internet Banking System/Single-Page Application[2]");
-            var oraclePrimary =
-                workspace.Model.GetElementWithCanonicalName("/Deployment/Live/Big Bank plc/bigbank-db01/Oracle - Primary");
-            var oracleSecondary =
-                workspace.Model.GetElementWithCanonicalName("/Deployment/Live/Big Bank plc/bigbank-db02/Oracle - Secondary");
+            //     Rel_Left(Live__BigBankplc__bigbankdb01__OraclePrimary, Live__BigBankplc__bigbankdb02__OracleSecondary, "Replicates data to")
+
+            // Model is changed that instances are counted per parent orig ...[2] cannot be used anymore, separate per view, full names have to be used
+            var developmentWebApplication = 
+                workspace.Model.GetElementWithCanonicalOrStaticalName("ContainerInstance://Development/Developer Laptop/Docker Container - Web Server/Apache Tomcat/Internet Banking System.Web Application[1]");
+            var developmentSinglePageApplication =
+                workspace.Model.GetElementWithCanonicalOrStaticalName("ContainerInstance://Development/Developer Laptop/Web Browser/Internet Banking System.Single-Page Application[1]");
             var developmentDeploymentView = workspace.Views.DeploymentViews.First();
-            var liveDeploymentView = workspace.Views.DeploymentViews.Last();
             developmentDeploymentView.Relationships
-                .First(r => r.Relationship.SourceId == webApplication1.Id &&
-                            r.Relationship.DestinationId == singlePageApplication1.Id)
+                .First(r => r.Relationship.SourceId == developmentWebApplication.Id &&
+                            r.Relationship.DestinationId == developmentSinglePageApplication.Id)
+                .SetDirection(DirectionValues.Up);
+
+            var liveWebApplication = 
+                workspace.Model.GetElementWithCanonicalOrStaticalName("ContainerInstance://Live/Big Bank plc/bigbank-web***/Apache Tomcat/Internet Banking System.Web Application[1]");
+            var liveSinglePageApplication =
+                workspace.Model.GetElementWithCanonicalOrStaticalName("ContainerInstance://Live/Customer's computer/Web Browser/Internet Banking System.Single-Page Application[1]");
+            var liveOraclePrimary =
+                workspace.Model.GetElementWithCanonicalOrStaticalName("DeploymentNode://Live/Big Bank plc/bigbank-db01/Oracle - Primary");
+            var liveOracleSecondary =
+                workspace.Model.GetElementWithCanonicalOrStaticalName("DeploymentNode://Live/Big Bank plc/bigbank-db02/Oracle - Secondary");
+            var liveDeploymentView = workspace.Views.DeploymentViews.Last();
+            liveDeploymentView.Relationships
+                .First(r => r.Relationship.SourceId == liveWebApplication.Id &&
+                            r.Relationship.DestinationId == liveSinglePageApplication.Id)
                 .SetDirection(DirectionValues.Up);
             liveDeploymentView.Relationships
-                .First(r => r.Relationship.SourceId == webApplication2.Id &&
-                            r.Relationship.DestinationId == singlePageApplication2.Id)
-                .SetDirection(DirectionValues.Up);
-            liveDeploymentView.Relationships
-                .First(r => r.Relationship.SourceId == oraclePrimary.Id && r.Relationship.DestinationId == oracleSecondary.Id)
+                .First(r => r.Relationship.SourceId == liveOraclePrimary.Id && r.Relationship.DestinationId == liveOracleSecondary.Id)
                 .SetDirection(DirectionValues.Left);
         }
 
@@ -721,17 +724,17 @@ Interact2(""3"", SoftwareSystem__WebApplication__SomeRepository__6d9009, Softwar
 !includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/master/C4_Deployment.puml
 
 ' Structurizr.DeploymentView: deployment
-title Software System - Deployment
+title Software System - Deployment - Default
 
 LAYOUT_WITH_LEGEND()
 
-Node(Deployment__Default__DatabaseServer__1edef6c, ""Database Server"", ""Ubuntu 12.04 LTS"") {
-  Node(Deployment__Default__DatabaseServer__MySQL__1fa4f18, ""MySQL"", ""MySQL 5.5.x"") {
+Node(DatabaseServer__1edef6c, ""Database Server"", ""Ubuntu 12.04 LTS"") {
+  Node(MySQL__1fa4f18, ""MySQL"", ""MySQL 5.5.x"") {
     ContainerDb(SoftwareSystem__Database1__bb9c73, ""Database"", ""Relational Database Schema"", ""Stores information"")
   }
 }
-Node(Deployment__Default__WebServer__1e2ffe, ""Web Server"", ""Ubuntu 12.04 LTS"") {
-  Node(Deployment__Default__WebServer__ApacheTomcat__2b8afb4, ""Apache Tomcat"", ""Apache Tomcat 8.x"") {
+Node(WebServer__1e2ffe, ""Web Server"", ""Ubuntu 12.04 LTS"") {
+  Node(ApacheTomcat__2b8afb4, ""Apache Tomcat"", ""Apache Tomcat 8.x"") {
     Container(SoftwareSystem__WebApplication1__31f1f25, ""Web Application"", ""Java and spring MVC"", ""Delivers content"")
   }
 }
@@ -1155,17 +1158,17 @@ endlegend
 !define Node(e_alias, e_label, e_techn) rectangle ""==e_label\n<size:TECHN_FONT_SIZE>[e_techn]</size>"" <<node>> as e_alias
 
 ' Structurizr.DeploymentView: deployment
-title Software System - Deployment
+title Software System - Deployment - Default
 
 LAYOUT_WITH_LEGEND()
 
-Node(Deployment__Default__DatabaseServer__1edef6c, ""Database Server"", ""Ubuntu 12.04 LTS"") {
-  Node(Deployment__Default__DatabaseServer__MySQL__1fa4f18, ""MySQL"", ""MySQL 5.5.x"") {
+Node(DatabaseServer__1edef6c, ""Database Server"", ""Ubuntu 12.04 LTS"") {
+  Node(MySQL__1fa4f18, ""MySQL"", ""MySQL 5.5.x"") {
     ContainerDb(SoftwareSystem__Database1__bb9c73, ""Database"", ""Relational Database Schema"", ""Stores information"")
   }
 }
-Node(Deployment__Default__WebServer__1e2ffe, ""Web Server"", ""Ubuntu 12.04 LTS"") {
-  Node(Deployment__Default__WebServer__ApacheTomcat__2b8afb4, ""Apache Tomcat"", ""Apache Tomcat 8.x"") {
+Node(WebServer__1e2ffe, ""Web Server"", ""Ubuntu 12.04 LTS"") {
+  Node(ApacheTomcat__2b8afb4, ""Apache Tomcat"", ""Apache Tomcat 8.x"") {
     Container(SoftwareSystem__WebApplication1__31f1f25, ""Web Application"", ""Java and spring MVC"", ""Delivers content"")
   }
 }
@@ -1189,17 +1192,17 @@ Rel(SoftwareSystem__WebApplication1__31f1f25, SoftwareSystem__Database1__bb9c73,
 !includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/master/C4_Deployment.puml
 
 ' Structurizr.DeploymentView: deployment
-title Software System - Deployment
+title Software System - Deployment - Default
 
 LAYOUT_WITH_LEGEND()
 
-Node(Deployment__Default__DatabaseServer__1edef6c, ""Database Server"", ""Ubuntu 12.04 LTS"") {
-  Node(Deployment__Default__DatabaseServer__MySQL__1fa4f18, ""MySQL"", ""MySQL 5.5.x"") {
+Node(DatabaseServer__1edef6c, ""Database Server"", ""Ubuntu 12.04 LTS"") {
+  Node(MySQL__1fa4f18, ""MySQL"", ""MySQL 5.5.x"") {
     ContainerDb(SoftwareSystem__Database1__bb9c73, ""Database"", ""Relational Database Schema"", ""Stores information"")
   }
 }
-Node(Deployment__Default__WebServer__1e2ffe, ""Web Server"", ""Ubuntu 12.04 LTS"") {
-  Node(Deployment__Default__WebServer__ApacheTomcat__2b8afb4, ""Apache Tomcat"", ""Apache Tomcat 8.x"") {
+Node(WebServer__1e2ffe, ""Web Server"", ""Ubuntu 12.04 LTS"") {
+  Node(ApacheTomcat__2b8afb4, ""Apache Tomcat"", ""Apache Tomcat 8.x"") {
     Container(SoftwareSystem__WebApplication1__31f1f25, ""Web Application"", ""Java and spring MVC"", ""Delivers content"")
   }
 }

--- a/Structurizr.PlantUML.Tests/IO/C4PlantUML/C4PlantUmlWriterTests.cs
+++ b/Structurizr.PlantUML.Tests/IO/C4PlantUML/C4PlantUmlWriterTests.cs
@@ -46,8 +46,6 @@ namespace Structurizr.IO.C4PlantUML.Tests
 ' Structurizr.SystemLandscapeView: SystemLandscape
 title System Landscape for Big Bank plc
 
-LAYOUT_WITH_LEGEND()
-
 Person_Ext(PersonalBankingCustomer__9bc576, ""Personal Banking Customer"", ""A customer of the bank, with personal bank accounts."")
 Enterprise_Boundary(BigBankplc, ""Big Bank plc"") {
   Person(BackOfficeStaff__5f761d, ""Back Office Staff"", ""Administration and support staff within the bank."")
@@ -66,6 +64,8 @@ Rel_Down(InternetBankingSystem__2aef74c, MainframeBankingSystem__f50ffa, ""Uses"
 Rel(PersonalBankingCustomer__9bc576, ATM__22fc739, ""Withdraws cash using"")
 Rel(PersonalBankingCustomer__9bc576, CustomerServiceStaff__a35be5, ""Asks questions to"", ""Telephone"")
 Rel(PersonalBankingCustomer__9bc576, InternetBankingSystem__2aef74c, ""Uses"")
+
+SHOW_LEGEND()
 @enduml
 
 @startuml
@@ -73,8 +73,6 @@ Rel(PersonalBankingCustomer__9bc576, InternetBankingSystem__2aef74c, ""Uses"")
 
 ' Structurizr.SystemContextView: SystemContext
 title Internet Banking System - System Context
-
-LAYOUT_WITH_LEGEND()
 
 System(EmailSystem__2908eb9, ""E-mail System"", ""The internal Microsoft Exchange e-mail system."")
 System(InternetBankingSystem__2aef74c, ""Internet Banking System"", ""Allows customers to view information about their bank accounts, and make payments."")
@@ -84,6 +82,8 @@ Rel_Up(EmailSystem__2908eb9, PersonalBankingCustomer__9bc576, ""Sends e-mails to
 Rel_Right(InternetBankingSystem__2aef74c, EmailSystem__2908eb9, ""Sends e-mail using"")
 Rel(InternetBankingSystem__2aef74c, MainframeBankingSystem__f50ffa, ""Uses"")
 Rel(PersonalBankingCustomer__9bc576, InternetBankingSystem__2aef74c, ""Uses"")
+
+SHOW_LEGEND()
 @enduml
 
 @startuml
@@ -91,8 +91,6 @@ Rel(PersonalBankingCustomer__9bc576, InternetBankingSystem__2aef74c, ""Uses"")
 
 ' Structurizr.ContainerView: Containers
 title Internet Banking System - Containers
-
-LAYOUT_WITH_LEGEND()
 
 System(EmailSystem__2908eb9, ""E-mail System"", ""The internal Microsoft Exchange e-mail system."")
 System(MainframeBankingSystem__f50ffa, ""Mainframe Banking System"", ""Stores all of the core banking information about customers, accounts, transactions, etc."")
@@ -114,6 +112,8 @@ Rel(PersonalBankingCustomer__9bc576, InternetBankingSystem__SinglePageApplicatio
 Rel(PersonalBankingCustomer__9bc576, InternetBankingSystem__WebApplication__1bb919c, ""Uses"", ""HTTPS"")
 Rel(InternetBankingSystem__SinglePageApplication__1414c79, InternetBankingSystem__APIApplication__2c36bed, ""Makes API calls to"", ""JSON/HTTPS"")
 Rel_Right(InternetBankingSystem__WebApplication__1bb919c, InternetBankingSystem__SinglePageApplication__1414c79, ""Delivers to the customer's web browser"")
+
+SHOW_LEGEND()
 @enduml
 
 @startuml
@@ -121,8 +121,6 @@ Rel_Right(InternetBankingSystem__WebApplication__1bb919c, InternetBankingSystem_
 
 ' Structurizr.ComponentView: Components
 title Internet Banking System - API Application - Components
-
-LAYOUT_WITH_LEGEND()
 
 ContainerDb(InternetBankingSystem__Database__18307f7, ""Database"", ""Relational Database Schema"", ""Stores user registration information, hashed authentication credentials, access logs, etc."")
 System(EmailSystem__2908eb9, ""E-mail System"", ""The internal Microsoft Exchange e-mail system."")
@@ -150,185 +148,15 @@ Rel(InternetBankingSystem__APIApplication__SignInController__22cc62b, InternetBa
 Rel(InternetBankingSystem__SinglePageApplication__1414c79, InternetBankingSystem__APIApplication__AccountsSummaryController__3f81fb2, ""Makes API calls to"", ""JSON/HTTPS"")
 Rel(InternetBankingSystem__SinglePageApplication__1414c79, InternetBankingSystem__APIApplication__ResetPasswordController__23f0eac, ""Makes API calls to"", ""JSON/HTTPS"")
 Rel(InternetBankingSystem__SinglePageApplication__1414c79, InternetBankingSystem__APIApplication__SignInController__22cc62b, ""Makes API calls to"", ""JSON/HTTPS"")
+
+SHOW_LEGEND()
 @enduml
 
 @startuml
-!include <C4/C4_Component>
-' C4_Dynamic.puml is missing, simulate it with following definitions
-' Scope: Interactions in an enterprise, software system or container.
-' Primary and supporting elements: Depends on the diagram scope - 
-'     enterprise - people and software systems related to the enterprise in scope 
-'     software system - see system context or container diagrams, 
-'     container - see component diagram.
-' Intended audience: Technical and non-technical people, inside and outside of the software development team.
-
-' Dynamic diagram introduces (automatically) numbered interactions: 
-'     Interact(): used automatic calculated index, 
-'     Interact2(): index can be explicit defined,
-'     SetIndex(): set the next index, 
-'     GetIndex(): get the index and automatically increase index
-
-' Index
-' ##################################
-
-!function $inc_($value, $step=1)
-  !return $value + $step
-!endfunction
-
-!$index=1
-
-!function SetIndex($new_index)
-  !$index=$new_index
-!endfunction
-
-!function GetIndex($auto_increase=1)
-  !$old = $index
-  !$index=$inc_($index, $auto_increase)
-  !return $old
-!endfunction
-
-' Interact
-' ##################################
-!define Interact2(e_index, e_from, e_to, e_label) Rel(e_from, e_to, ""e_index: e_label"")
-!define Interact2(e_index, e_from, e_to, e_label, e_techn) Rel(e_from, e_to, ""e_index: e_label"", e_techn)
-
-!define Interact2_Back(e_index, e_from, e_to, e_label) Rel_Back(e_from, e_to, ""e_index: e_label"")
-!define Interact2_Back(e_index, e_from, e_to, e_label, e_techn) Rel_Back(e_from, e_to, ""e_index: e_label"", e_techn)
-
-!define Interact2_Neighbor(e_index, e_from, e_to, e_label) Rel_Neighbor(e_from, e_to, ""e_index: e_label"")
-!define Interact2_Neighbor(e_index, e_from, e_to, e_label, e_techn) Rel_Neighbor(e_from, e_to, ""e_index: e_label"", e_techn)
-
-!define Interact2_Back_Neighbor(e_index, e_from, e_to, e_label) Rel_Back_Neighbor(e_from, e_to, ""e_index: e_label"")
-!define Interact2_Back_Neighbor(e_index, e_from, e_to, e_label, e_techn) Rel_Back_Neighbor(e_from, e_to, ""e_index: e_label"", e_techn)
-
-!define Interact2_D(e_index, e_from, e_to, e_label) Rel_D(e_from, e_to, ""e_index: e_label"")
-!define Interact2_D(e_index, e_from, e_to, e_label, e_techn) Rel_D(e_from, e_to, ""e_index: e_label"", e_techn)
-!define Interact2_Down(e_index, e_from, e_to, e_label) Rel_Down(e_from, e_to, ""e_index: e_label"")
-!define Interact2_Down(e_index, e_from, e_to, e_label, e_techn) Rel_Down(e_from, e_to, ""e_index: e_label"", e_techn)
-
-!define Interact2_U(e_index, e_from, e_to, e_label) Rel_U(e_from, e_to, ""e_index: e_label"")
-!define Interact2_U(e_index, e_from, e_to, e_label, e_techn) Rel_U(e_from, e_to, ""e_index: e_label"", e_techn)
-!define Interact2_Up(e_index, e_from, e_to, e_label) Rel_Up(e_from, e_to, ""e_index: e_label"")
-!define Interact2_Up(e_index, e_from, e_to, e_label, e_techn) Rel_Up(e_from, e_to, ""e_index: e_label"", e_techn)
-
-!define Interact2_L(e_index, e_from, e_to, e_label) Rel_L(e_from, e_to, ""e_index: e_label"")
-!define Interact2_L(e_index, e_from, e_to, e_label, e_techn) Rel_L(e_from, e_to, ""e_index: e_label"", e_techn)
-!define Interact2_Left(e_index, e_from, e_to, e_label) Rel_Left(e_from, e_to, ""e_index: e_label"")
-!define Interact2_Left(e_index, e_from, e_to, e_label, e_techn) Rel_Left(e_from, e_to, ""e_index: e_label"", e_techn)
-
-!define Interact2_R(e_index, e_from, e_to, e_label) Rel_R(e_from, e_to, ""e_index: e_label"")
-!define Interact2_R(e_index, e_from, e_to, e_label, e_techn) Rel_R(e_from, e_to, ""e_index: e_label"", e_techn)
-!define Interact2_Right(e_index, e_from, e_to, e_label) Rel_Right(e_from, e_to, ""e_index: e_label"")
-!define Interact2_Right(e_index, e_from, e_to, e_label, e_techn) Rel_Right(e_from, e_to, ""e_index: e_label"", e_techn)
-
-!unquoted function Interact($e_from, $e_to, $e_label) 
-  Interact2($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact($e_from, $e_to, $e_label, $e_techn) 
-  Interact2($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-
-!unquoted function Interact_Back($e_from, $e_to, $e_label) 
-  Interact2_Back($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Back($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_Back($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-
-!unquoted function Interact_Neighbor($e_from, $e_to, $e_label) 
-  Interact2_Neighbor($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Neighbor($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_Neighbor($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-
-!unquoted function Interact_Back_Neighbor($e_from, $e_to, $e_label) 
-  Interact2_Back_Neighbor($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Back_Neighbor($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_Back_Neighbor($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-
-!unquoted function Interact_D($e_from, $e_to, $e_label) 
-  Interact2_D($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_D($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_D($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Down($e_from, $e_to, $e_label) 
-  Interact2_Down($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Down($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_Down($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-
-!unquoted function Interact_U($e_from, $e_to, $e_label) 
-  Interact2_U($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_U($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_U($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Up($e_from, $e_to, $e_label) 
-  Interact2_Up($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Up($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_Up($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-
-!unquoted function Interact_L($e_from, $e_to, $e_label) 
-  Interact2_L($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_L($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_L($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Left($e_from, $e_to, $e_label) 
-  Interact2_Left($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Left($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_Left($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-
-!unquoted function Interact_R($e_from, $e_to, $e_label) 
-  Interact2_R($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_R($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_R($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Right($e_from, $e_to, $e_label) 
-  Interact2_Right($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Right($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_Right($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
+!include <C4/C4_Dynamic>
 
 ' Structurizr.DynamicView: SignIn
 title API Application - Dynamic
-
-LAYOUT_WITH_LEGEND()
 
 ContainerDb(InternetBankingSystem__Database__18307f7, ""Database"", ""Relational Database Schema"", ""Stores user registration information, hashed authentication credentials, access logs, etc."")
 Container(InternetBankingSystem__SinglePageApplication__1414c79, ""Single-Page Application"", ""JavaScript and Angular"", ""Provides all of the Internet banking functionality to customers via their web browser."")
@@ -336,58 +164,20 @@ Container_Boundary(InternetBankingSystem__APIApplication__2c36bed, ""API Applica
   Component(InternetBankingSystem__APIApplication__SecurityComponent__a4474, ""Security Component"", ""Spring Bean"", ""Provides functionality related to signing in, changing passwords, etc."")
   Component(InternetBankingSystem__APIApplication__SignInController__22cc62b, ""Sign In Controller"", ""Spring MVC Rest Controller"", ""Allows users to sign in to the Internet Banking System."")
 }
-Interact2_Right(""1"", InternetBankingSystem__SinglePageApplication__1414c79, InternetBankingSystem__APIApplication__SignInController__22cc62b, ""Submits credentials to"", ""JSON/HTTPS"")
-Interact2(""2"", InternetBankingSystem__APIApplication__SignInController__22cc62b, InternetBankingSystem__APIApplication__SecurityComponent__a4474, ""Calls isAuthenticated() on"")
-Interact2_Right(""3"", InternetBankingSystem__APIApplication__SecurityComponent__a4474, InternetBankingSystem__Database__18307f7, ""select * from users where username = ?"", ""JDBC"")
+RelIndex_Right(""1"", InternetBankingSystem__SinglePageApplication__1414c79, InternetBankingSystem__APIApplication__SignInController__22cc62b, ""Submits credentials to"", ""JSON/HTTPS"")
+RelIndex(""2"", InternetBankingSystem__APIApplication__SignInController__22cc62b, InternetBankingSystem__APIApplication__SecurityComponent__a4474, ""Calls isAuthenticated() on"")
+RelIndex_Right(""3"", InternetBankingSystem__APIApplication__SecurityComponent__a4474, InternetBankingSystem__Database__18307f7, ""select * from users where username = ?"", ""JDBC"")
+
+SHOW_LEGEND()
 @enduml
 
 @startuml
-!include <C4/C4_Container>
-' C4_Deployment.puml is missing, simulate it with following definitions
-' Scope: A single software system.
-' Primary elements: Deployment nodes and containers within the software system in scope.
-' Intended audience: Technical people inside and outside of the software development team; including software architects, developers and operations/support staff.
-
-' Colors
-' ##################################
-!define NODE_FONT_COLOR    #444444
-!define NODE_BG_COLOR      #FFFFFF
-
-' Styling
-' ##################################
-
-skinparam rectangle<<node>> {
-  Shadowing false
-  StereotypeFontSize 0
-  FontColor NODE_FONT_COLOR
-  BackgroundColor NODE_BG_COLOR
-  BorderColor #444444
-}
-
-' Layout
-' ##################################
-
-!definelong LAYOUT_WITH_LEGEND
-hide stereotype
-legend right
-|=                    |= Type                |
-|<NODE_BG_COLOR>      | deployment node      |
-|<CONTAINER_BG_COLOR> | deployment container |
-endlegend
-!enddefinelong
-
-' Nodes
-' ##################################
-' PlantUML does not support automatic line breaks of container, if e_techn is very long insert line breaks with 
-' ""</size>\n<size:TECHN_FONT_SIZE>""
-!define Node(e_alias, e_label, e_techn) rectangle ""==e_label\n<size:TECHN_FONT_SIZE>[e_techn]</size>"" <<node>> as e_alias
+!include <C4/C4_Deployment>
 
 ' Structurizr.DeploymentView: DevelopmentDeployment
 title Internet Banking System - Deployment - Development
 
-LAYOUT_WITH_LEGEND()
-
-Node(DeveloperLaptop__389f399, ""Developer Laptop"", ""Microsoft Windows 10 or Apple </size>\n<size:TECHN_FONT_SIZE>macOS"") {
+Node(DeveloperLaptop__389f399, ""Developer Laptop"", ""Microsoft Windows 10 or Apple macOS"") {
   Node(DockerContainerWebServer__1b73d2e, ""Docker Container - Web Server"", ""Docker"") {
     Node(ApacheTomcat__1cc9f55, ""Apache Tomcat"", ""Apache Tomcat 8.x"") {
       Container(InternetBankingSystem__WebApplication1__28f79f6, ""Web Application"", ""Java and Spring MVC"", ""Delivers the static content and the Internet banking single page application."")
@@ -399,60 +189,22 @@ Node(DeveloperLaptop__389f399, ""Developer Laptop"", ""Microsoft Windows 10 or A
       ContainerDb(InternetBankingSystem__Database1__3296ca6, ""Database"", ""Relational Database Schema"", ""Stores user registration information, hashed authentication credentials, access logs, etc."")
     }
   }
-  Node(WebBrowser__3930fd, ""Web Browser"", ""Google Chrome, Mozilla </size>\n<size:TECHN_FONT_SIZE>Firefox, Apple Safari or </size>\n<size:TECHN_FONT_SIZE>Microsoft Edge"") {
+  Node(WebBrowser__3930fd, ""Web Browser"", ""Google Chrome, Mozilla Firefox, Apple Safari or Microsoft Edge"") {
     Container(InternetBankingSystem__SinglePageApplication1__bbe85d, ""Single-Page Application"", ""JavaScript and Angular"", ""Provides all of the Internet banking functionality to customers via their web browser."")
   }
 }
 Rel(InternetBankingSystem__APIApplication1__1f227f4, InternetBankingSystem__Database1__3296ca6, ""Reads from and writes to"", ""JDBC"")
 Rel(InternetBankingSystem__SinglePageApplication1__bbe85d, InternetBankingSystem__APIApplication1__1f227f4, ""Makes API calls to"", ""JSON/HTTPS"")
 Rel_Up(InternetBankingSystem__WebApplication1__28f79f6, InternetBankingSystem__SinglePageApplication1__bbe85d, ""Delivers to the customer's web browser"")
+
+SHOW_LEGEND()
 @enduml
 
 @startuml
-!include <C4/C4_Container>
-' C4_Deployment.puml is missing, simulate it with following definitions
-' Scope: A single software system.
-' Primary elements: Deployment nodes and containers within the software system in scope.
-' Intended audience: Technical people inside and outside of the software development team; including software architects, developers and operations/support staff.
-
-' Colors
-' ##################################
-!define NODE_FONT_COLOR    #444444
-!define NODE_BG_COLOR      #FFFFFF
-
-' Styling
-' ##################################
-
-skinparam rectangle<<node>> {
-  Shadowing false
-  StereotypeFontSize 0
-  FontColor NODE_FONT_COLOR
-  BackgroundColor NODE_BG_COLOR
-  BorderColor #444444
-}
-
-' Layout
-' ##################################
-
-!definelong LAYOUT_WITH_LEGEND
-hide stereotype
-legend right
-|=                    |= Type                |
-|<NODE_BG_COLOR>      | deployment node      |
-|<CONTAINER_BG_COLOR> | deployment container |
-endlegend
-!enddefinelong
-
-' Nodes
-' ##################################
-' PlantUML does not support automatic line breaks of container, if e_techn is very long insert line breaks with 
-' ""</size>\n<size:TECHN_FONT_SIZE>""
-!define Node(e_alias, e_label, e_techn) rectangle ""==e_label\n<size:TECHN_FONT_SIZE>[e_techn]</size>"" <<node>> as e_alias
+!include <C4/C4_Deployment>
 
 ' Structurizr.DeploymentView: LiveDeployment
 title Internet Banking System - Deployment - Live
-
-LAYOUT_WITH_LEGEND()
 
 Node(BigBankplc__3ffe15e, ""Big Bank plc"", ""Big Bank plc data center"") {
   Node(bigbankweb***__3f92e18, ""bigbank-web*** (x4)"", ""Ubuntu 16.04 LTS"") {
@@ -476,8 +228,8 @@ Node(BigBankplc__3ffe15e, ""Big Bank plc"", ""Big Bank plc data center"") {
     }
   }
 }
-Node(Customer'scomputer__2510bf3, ""Customer's computer"", ""Microsoft Windows or Apple </size>\n<size:TECHN_FONT_SIZE>macOS"") {
-  Node(WebBrowser__ba951, ""Web Browser"", ""Google Chrome, Mozilla </size>\n<size:TECHN_FONT_SIZE>Firefox, Apple Safari or </size>\n<size:TECHN_FONT_SIZE>Microsoft Edge"") {
+Node(Customer'scomputer__2510bf3, ""Customer's computer"", ""Microsoft Windows or Apple macOS"") {
+  Node(WebBrowser__ba951, ""Web Browser"", ""Google Chrome, Mozilla Firefox, Apple Safari or Microsoft Edge"") {
     Container(InternetBankingSystem__SinglePageApplication1__298b31c, ""Single-Page Application"", ""JavaScript and Angular"", ""Provides all of the Internet banking functionality to customers via their web browser."")
   }
 }
@@ -490,6 +242,8 @@ Rel(InternetBankingSystem__MobileApp1__d004b3, InternetBankingSystem__APIApplica
 Rel_Left(OraclePrimary__19fd8f, OracleSecondary__1c4ec22, ""Replicates data to"")
 Rel(InternetBankingSystem__SinglePageApplication1__298b31c, InternetBankingSystem__APIApplication1__1408a33, ""Makes API calls to"", ""JSON/HTTPS"")
 Rel_Up(InternetBankingSystem__WebApplication1__1720850, InternetBankingSystem__SinglePageApplication1__298b31c, ""Delivers to the customer's web browser"")
+
+SHOW_LEGEND()
 @enduml
 
 ".UnifyNewLine().UnifyHashValues(), _stringWriter.ToString().UnifyHashValues());
@@ -618,16 +372,14 @@ Rel_Up(InternetBankingSystem__WebApplication1__1720850, InternetBankingSystem__S
         {
             PopulateWorkspace();
 
-            _plantUMLWriter.CustomBaseUrl = @"https://raw.githubusercontent.com/kirchsth/C4-PlantUML/master/";
+            _plantUMLWriter.CustomBaseUrl = @"https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/";
             _plantUMLWriter.Write(_workspace, _stringWriter);
             Assert.Equal(
 @"@startuml
-!includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/master/C4_Context.puml
+!includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Context.puml
 
 ' Structurizr.SystemLandscapeView: enterpriseContext
 title System Landscape for Some Enterprise
-
-LAYOUT_WITH_LEGEND()
 
 System_Ext(EmailSystem__1127701, ""E-mail System"")
 Enterprise_Boundary(SomeEnterprise, ""Some Enterprise"") {
@@ -637,15 +389,15 @@ Enterprise_Boundary(SomeEnterprise, ""Some Enterprise"") {
 Rel(EmailSystem__1127701, User__387cc75, ""Delivers e-mails to"")
 Rel(SoftwareSystem__31d545b, EmailSystem__1127701, ""Sends e-mail using"")
 Rel(User__387cc75, SoftwareSystem__31d545b, ""Uses"")
+
+SHOW_LEGEND()
 @enduml
 
 @startuml
-!includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/master/C4_Context.puml
+!includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Context.puml
 
 ' Structurizr.SystemContextView: systemContext
 title Software System - System Context
-
-LAYOUT_WITH_LEGEND()
 
 Enterprise_Boundary(SomeEnterprise, ""Some Enterprise"") {
   System_Ext(EmailSystem__1127701, ""E-mail System"")
@@ -655,15 +407,15 @@ Rel(EmailSystem__1127701, User__387cc75, ""Delivers e-mails to"")
 Rel(SoftwareSystem__31d545b, EmailSystem__1127701, ""Sends e-mail using"")
 Rel(User__387cc75, SoftwareSystem__31d545b, ""Uses"")
 }
+
+SHOW_LEGEND()
 @enduml
 
 @startuml
-!includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/master/C4_Container.puml
+!includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Container.puml
 
 ' Structurizr.ContainerView: containers
 title Software System - Containers
-
-LAYOUT_WITH_LEGEND()
 
 System_Ext(EmailSystem__1127701, ""E-mail System"")
 Person(User__387cc75, ""User"")
@@ -675,15 +427,15 @@ Rel(EmailSystem__1127701, User__387cc75, ""Delivers e-mails to"")
 Rel(User__387cc75, SoftwareSystem__WebApplication__d2a342, """", ""HTTP"")
 Rel(SoftwareSystem__WebApplication__d2a342, SoftwareSystem__Database__39bccb8, ""Reads from and writes to"", ""JDBC"")
 Rel(SoftwareSystem__WebApplication__d2a342, EmailSystem__1127701, ""Sends e-mail using"")
+
+SHOW_LEGEND()
 @enduml
 
 @startuml
-!includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/master/C4_Component.puml
+!includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Component.puml
 
 ' Structurizr.ComponentView: components
 title Software System - Web Application - Components
-
-LAYOUT_WITH_LEGEND()
 
 ContainerDb(SoftwareSystem__Database__39bccb8, ""Database"", ""Relational Database Schema"", ""Stores information"")
 System_Ext(EmailSystem__1127701, ""E-mail System"")
@@ -699,15 +451,15 @@ Rel(SoftwareSystem__WebApplication__SomeController__341621c, SoftwareSystem__Web
 Rel(SoftwareSystem__WebApplication__SomeController__341621c, SoftwareSystem__WebApplication__SomeRepository__6d9009, ""Uses"")
 Rel(SoftwareSystem__WebApplication__SomeRepository__6d9009, SoftwareSystem__Database__39bccb8, ""Reads from and writes to"", ""JDBC"")
 Rel(User__387cc75, SoftwareSystem__WebApplication__SomeController__341621c, ""Uses"", ""HTTP"")
+
+SHOW_LEGEND()
 @enduml
 
 @startuml
-!includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/master/C4_Dynamic.puml
+!includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Dynamic.puml
 
 ' Structurizr.DynamicView: dynamic
 title Web Application - Dynamic
-
-LAYOUT_WITH_LEGEND()
 
 ContainerDb(SoftwareSystem__Database__39bccb8, ""Database"", ""Relational Database Schema"", ""Stores information"")
 Person(User__387cc75, ""User"")
@@ -715,18 +467,18 @@ Container_Boundary(SoftwareSystem__WebApplication__d2a342, ""Web Application"") 
   Component(SoftwareSystem__WebApplication__SomeController__341621c, ""SomeController"", ""Spring MVC Controller"")
   Component(SoftwareSystem__WebApplication__SomeRepository__6d9009, ""SomeRepository"", ""Spring Data"")
 }
-Interact2(""1"", User__387cc75, SoftwareSystem__WebApplication__SomeController__341621c, ""Requests /something"", ""HTTP"")
-Interact2(""2"", SoftwareSystem__WebApplication__SomeController__341621c, SoftwareSystem__WebApplication__SomeRepository__6d9009, """")
-Interact2(""3"", SoftwareSystem__WebApplication__SomeRepository__6d9009, SoftwareSystem__Database__39bccb8, ""select * from something"", ""JDBC"")
+RelIndex(""1"", User__387cc75, SoftwareSystem__WebApplication__SomeController__341621c, ""Requests /something"", ""HTTP"")
+RelIndex(""2"", SoftwareSystem__WebApplication__SomeController__341621c, SoftwareSystem__WebApplication__SomeRepository__6d9009, """")
+RelIndex(""3"", SoftwareSystem__WebApplication__SomeRepository__6d9009, SoftwareSystem__Database__39bccb8, ""select * from something"", ""JDBC"")
+
+SHOW_LEGEND()
 @enduml
 
 @startuml
-!includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/master/C4_Deployment.puml
+!includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Deployment.puml
 
 ' Structurizr.DeploymentView: deployment
 title Software System - Deployment - Default
-
-LAYOUT_WITH_LEGEND()
 
 Node(DatabaseServer__1edef6c, ""Database Server"", ""Ubuntu 12.04 LTS"") {
   Node(MySQL__1fa4f18, ""MySQL"", ""MySQL 5.5.x"") {
@@ -739,6 +491,8 @@ Node(WebServer__1e2ffe, ""Web Server"", ""Ubuntu 12.04 LTS"") {
   }
 }
 Rel(SoftwareSystem__WebApplication1__31f1f25, SoftwareSystem__Database1__bb9c73, ""Reads from and writes to"", ""JDBC"")
+
+SHOW_LEGEND()
 @enduml
 
 ".UnifyNewLine().UnifyHashValues(), _stringWriter.ToString().UnifyHashValues());
@@ -759,8 +513,6 @@ Rel(SoftwareSystem__WebApplication1__31f1f25, SoftwareSystem__Database1__bb9c73,
 ' Structurizr.SystemLandscapeView: enterpriseContext
 title System Landscape for Some Enterprise
 
-LAYOUT_WITH_LEGEND()
-
 System_Ext(EmailSystem__1934cbe, ""E-mail System"")
 Enterprise_Boundary(SomeEnterprise, ""Some Enterprise"") {
   Person(User__3b843b5, ""User"")
@@ -769,6 +521,8 @@ Enterprise_Boundary(SomeEnterprise, ""Some Enterprise"") {
 Rel(EmailSystem__1934cbe, User__3b843b5, ""Delivers e-mails to"")
 Rel(SoftwareSystem__7134f, EmailSystem__1934cbe, ""Sends e-mail using"")
 Rel(User__3b843b5, SoftwareSystem__7134f, ""Uses"")
+
+SHOW_LEGEND()
 @enduml
 
 ".UnifyNewLine().UnifyHashValues(), _stringWriter.ToString().UnifyHashValues());
@@ -781,17 +535,15 @@ Rel(User__3b843b5, SoftwareSystem__7134f, ""Uses"")
             PopulateWorkspace();
             SystemLandscapeView systemLandscapeView = _workspace.Views.SystemLandscapeViews.First();
 
-            _plantUMLWriter.CustomBaseUrl = @"https://raw.githubusercontent.com/kirchsth/C4-PlantUML/master/";
+            _plantUMLWriter.CustomBaseUrl = @"https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/";
             _plantUMLWriter.Write(systemLandscapeView, _stringWriter);
 
             Assert.Equal(
                 @"@startuml
-!includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/master/C4_Context.puml
+!includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Context.puml
 
 ' Structurizr.SystemLandscapeView: enterpriseContext
 title System Landscape for Some Enterprise
-
-LAYOUT_WITH_LEGEND()
 
 System_Ext(EmailSystem__1934cbe, ""E-mail System"")
 Enterprise_Boundary(SomeEnterprise, ""Some Enterprise"") {
@@ -801,6 +553,8 @@ Enterprise_Boundary(SomeEnterprise, ""Some Enterprise"") {
 Rel(EmailSystem__1934cbe, User__3b843b5, ""Delivers e-mails to"")
 Rel(SoftwareSystem__7134f, EmailSystem__1934cbe, ""Sends e-mail using"")
 Rel(User__3b843b5, SoftwareSystem__7134f, ""Uses"")
+
+SHOW_LEGEND()
 @enduml
 
 ".UnifyNewLine().UnifyHashValues(), _stringWriter.ToString().UnifyHashValues());
@@ -822,8 +576,6 @@ Rel(User__3b843b5, SoftwareSystem__7134f, ""Uses"")
 ' Structurizr.SystemContextView: systemContext
 title Software System - System Context
 
-LAYOUT_WITH_LEGEND()
-
 Enterprise_Boundary(SomeEnterprise, ""Some Enterprise"") {
   System_Ext(EmailSystem__1127701, ""E-mail System"")
   System(SoftwareSystem__31d545b, ""Software System"")
@@ -832,6 +584,8 @@ Rel(EmailSystem__1127701, User__387cc75, ""Delivers e-mails to"")
 Rel(SoftwareSystem__31d545b, EmailSystem__1127701, ""Sends e-mail using"")
 Rel(User__387cc75, SoftwareSystem__31d545b, ""Uses"")
 }
+
+SHOW_LEGEND()
 @enduml
 
 ".UnifyNewLine().UnifyHashValues(), _stringWriter.ToString().UnifyHashValues());
@@ -852,8 +606,6 @@ Rel(User__387cc75, SoftwareSystem__31d545b, ""Uses"")
 ' Structurizr.ContainerView: containers
 title Software System - Containers
 
-LAYOUT_WITH_LEGEND()
-
 System_Ext(EmailSystem__1934cbe, ""E-mail System"")
 Person(User__3b843b5, ""User"")
 System_Boundary(SoftwareSystem__7134f, ""Software System"") {
@@ -864,6 +616,8 @@ Rel(EmailSystem__1934cbe, User__3b843b5, ""Delivers e-mails to"")
 Rel(User__3b843b5, SoftwareSystem__WebApplication__1cc1659, """", ""HTTP"")
 Rel(SoftwareSystem__WebApplication__1cc1659, SoftwareSystem__Database__270f9f2, ""Reads from and writes to"", ""JDBC"")
 Rel(SoftwareSystem__WebApplication__1cc1659, EmailSystem__1934cbe, ""Sends e-mail using"")
+
+SHOW_LEGEND()
 @enduml
 
 ".UnifyNewLine().UnifyHashValues(), _stringWriter.ToString().UnifyHashValues());
@@ -884,8 +638,6 @@ Rel(SoftwareSystem__WebApplication__1cc1659, EmailSystem__1934cbe, ""Sends e-mai
 ' Structurizr.ComponentView: components
 title Software System - Web Application - Components
 
-LAYOUT_WITH_LEGEND()
-
 ContainerDb(SoftwareSystem__Database__270f9f2, ""Database"", ""Relational Database Schema"", ""Stores information"")
 System_Ext(EmailSystem__1934cbe, ""E-mail System"")
 Person(User__3b843b5, ""User"")
@@ -900,6 +652,8 @@ Rel(SoftwareSystem__WebApplication__SomeController__327a713, SoftwareSystem__Web
 Rel(SoftwareSystem__WebApplication__SomeController__327a713, SoftwareSystem__WebApplication__SomeRepository__23f6823, ""Uses"")
 Rel(SoftwareSystem__WebApplication__SomeRepository__23f6823, SoftwareSystem__Database__270f9f2, ""Reads from and writes to"", ""JDBC"")
 Rel(User__3b843b5, SoftwareSystem__WebApplication__SomeController__327a713, ""Uses"", ""HTTP"")
+
+SHOW_LEGEND()
 @enduml
 
 ".UnifyNewLine().UnifyHashValues(), _stringWriter.ToString().UnifyHashValues());
@@ -916,182 +670,10 @@ Rel(User__3b843b5, SoftwareSystem__WebApplication__SomeController__327a713, ""Us
             // Dynamic diagrams can be drawn with Components 
             Assert.Equal(
 @"@startuml
-!include <C4/C4_Component>
-' C4_Dynamic.puml is missing, simulate it with following definitions
-' Scope: Interactions in an enterprise, software system or container.
-' Primary and supporting elements: Depends on the diagram scope - 
-'     enterprise - people and software systems related to the enterprise in scope 
-'     software system - see system context or container diagrams, 
-'     container - see component diagram.
-' Intended audience: Technical and non-technical people, inside and outside of the software development team.
-
-' Dynamic diagram introduces (automatically) numbered interactions: 
-'     Interact(): used automatic calculated index, 
-'     Interact2(): index can be explicit defined,
-'     SetIndex(): set the next index, 
-'     GetIndex(): get the index and automatically increase index
-
-' Index
-' ##################################
-
-!function $inc_($value, $step=1)
-  !return $value + $step
-!endfunction
-
-!$index=1
-
-!function SetIndex($new_index)
-  !$index=$new_index
-!endfunction
-
-!function GetIndex($auto_increase=1)
-  !$old = $index
-  !$index=$inc_($index, $auto_increase)
-  !return $old
-!endfunction
-
-' Interact
-' ##################################
-!define Interact2(e_index, e_from, e_to, e_label) Rel(e_from, e_to, ""e_index: e_label"")
-!define Interact2(e_index, e_from, e_to, e_label, e_techn) Rel(e_from, e_to, ""e_index: e_label"", e_techn)
-
-!define Interact2_Back(e_index, e_from, e_to, e_label) Rel_Back(e_from, e_to, ""e_index: e_label"")
-!define Interact2_Back(e_index, e_from, e_to, e_label, e_techn) Rel_Back(e_from, e_to, ""e_index: e_label"", e_techn)
-
-!define Interact2_Neighbor(e_index, e_from, e_to, e_label) Rel_Neighbor(e_from, e_to, ""e_index: e_label"")
-!define Interact2_Neighbor(e_index, e_from, e_to, e_label, e_techn) Rel_Neighbor(e_from, e_to, ""e_index: e_label"", e_techn)
-
-!define Interact2_Back_Neighbor(e_index, e_from, e_to, e_label) Rel_Back_Neighbor(e_from, e_to, ""e_index: e_label"")
-!define Interact2_Back_Neighbor(e_index, e_from, e_to, e_label, e_techn) Rel_Back_Neighbor(e_from, e_to, ""e_index: e_label"", e_techn)
-
-!define Interact2_D(e_index, e_from, e_to, e_label) Rel_D(e_from, e_to, ""e_index: e_label"")
-!define Interact2_D(e_index, e_from, e_to, e_label, e_techn) Rel_D(e_from, e_to, ""e_index: e_label"", e_techn)
-!define Interact2_Down(e_index, e_from, e_to, e_label) Rel_Down(e_from, e_to, ""e_index: e_label"")
-!define Interact2_Down(e_index, e_from, e_to, e_label, e_techn) Rel_Down(e_from, e_to, ""e_index: e_label"", e_techn)
-
-!define Interact2_U(e_index, e_from, e_to, e_label) Rel_U(e_from, e_to, ""e_index: e_label"")
-!define Interact2_U(e_index, e_from, e_to, e_label, e_techn) Rel_U(e_from, e_to, ""e_index: e_label"", e_techn)
-!define Interact2_Up(e_index, e_from, e_to, e_label) Rel_Up(e_from, e_to, ""e_index: e_label"")
-!define Interact2_Up(e_index, e_from, e_to, e_label, e_techn) Rel_Up(e_from, e_to, ""e_index: e_label"", e_techn)
-
-!define Interact2_L(e_index, e_from, e_to, e_label) Rel_L(e_from, e_to, ""e_index: e_label"")
-!define Interact2_L(e_index, e_from, e_to, e_label, e_techn) Rel_L(e_from, e_to, ""e_index: e_label"", e_techn)
-!define Interact2_Left(e_index, e_from, e_to, e_label) Rel_Left(e_from, e_to, ""e_index: e_label"")
-!define Interact2_Left(e_index, e_from, e_to, e_label, e_techn) Rel_Left(e_from, e_to, ""e_index: e_label"", e_techn)
-
-!define Interact2_R(e_index, e_from, e_to, e_label) Rel_R(e_from, e_to, ""e_index: e_label"")
-!define Interact2_R(e_index, e_from, e_to, e_label, e_techn) Rel_R(e_from, e_to, ""e_index: e_label"", e_techn)
-!define Interact2_Right(e_index, e_from, e_to, e_label) Rel_Right(e_from, e_to, ""e_index: e_label"")
-!define Interact2_Right(e_index, e_from, e_to, e_label, e_techn) Rel_Right(e_from, e_to, ""e_index: e_label"", e_techn)
-
-!unquoted function Interact($e_from, $e_to, $e_label) 
-  Interact2($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact($e_from, $e_to, $e_label, $e_techn) 
-  Interact2($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-
-!unquoted function Interact_Back($e_from, $e_to, $e_label) 
-  Interact2_Back($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Back($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_Back($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-
-!unquoted function Interact_Neighbor($e_from, $e_to, $e_label) 
-  Interact2_Neighbor($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Neighbor($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_Neighbor($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-
-!unquoted function Interact_Back_Neighbor($e_from, $e_to, $e_label) 
-  Interact2_Back_Neighbor($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Back_Neighbor($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_Back_Neighbor($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-
-!unquoted function Interact_D($e_from, $e_to, $e_label) 
-  Interact2_D($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_D($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_D($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Down($e_from, $e_to, $e_label) 
-  Interact2_Down($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Down($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_Down($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-
-!unquoted function Interact_U($e_from, $e_to, $e_label) 
-  Interact2_U($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_U($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_U($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Up($e_from, $e_to, $e_label) 
-  Interact2_Up($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Up($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_Up($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-
-!unquoted function Interact_L($e_from, $e_to, $e_label) 
-  Interact2_L($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_L($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_L($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Left($e_from, $e_to, $e_label) 
-  Interact2_Left($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Left($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_Left($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-
-!unquoted function Interact_R($e_from, $e_to, $e_label) 
-  Interact2_R($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_R($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_R($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Right($e_from, $e_to, $e_label) 
-  Interact2_Right($index, ""$e_from"", ""$e_to"", ""$e_label"")
-  !$index=$inc_($index)
-!endfunction
-!unquoted function Interact_Right($e_from, $e_to, $e_label, $e_techn) 
-  Interact2_Right($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)
-  !$index=$inc_($index)
-!endfunction
+!include <C4/C4_Dynamic>
 
 ' Structurizr.DynamicView: dynamic
 title Web Application - Dynamic
-
-LAYOUT_WITH_LEGEND()
 
 ContainerDb(SoftwareSystem__Database__39bccb8, ""Database"", ""Relational Database Schema"", ""Stores information"")
 Person(User__387cc75, ""User"")
@@ -1099,9 +681,11 @@ Container_Boundary(SoftwareSystem__WebApplication__d2a342, ""Web Application"") 
   Component(SoftwareSystem__WebApplication__SomeController__341621c, ""SomeController"", ""Spring MVC Controller"")
   Component(SoftwareSystem__WebApplication__SomeRepository__6d9009, ""SomeRepository"", ""Spring Data"")
 }
-Interact2(""1"", User__387cc75, SoftwareSystem__WebApplication__SomeController__341621c, ""Requests /something"", ""HTTP"")
-Interact2(""2"", SoftwareSystem__WebApplication__SomeController__341621c, SoftwareSystem__WebApplication__SomeRepository__6d9009, """")
-Interact2(""3"", SoftwareSystem__WebApplication__SomeRepository__6d9009, SoftwareSystem__Database__39bccb8, ""select * from something"", ""JDBC"")
+RelIndex(""1"", User__387cc75, SoftwareSystem__WebApplication__SomeController__341621c, ""Requests /something"", ""HTTP"")
+RelIndex(""2"", SoftwareSystem__WebApplication__SomeController__341621c, SoftwareSystem__WebApplication__SomeRepository__6d9009, """")
+RelIndex(""3"", SoftwareSystem__WebApplication__SomeRepository__6d9009, SoftwareSystem__Database__39bccb8, ""select * from something"", ""JDBC"")
+
+SHOW_LEGEND()
 @enduml
 
 ".UnifyNewLine().UnifyHashValues(), _stringWriter.ToString().UnifyHashValues());
@@ -1117,50 +701,10 @@ Interact2(""3"", SoftwareSystem__WebApplication__SomeRepository__6d9009, Softwar
 
             Assert.Equal(
 @"@startuml
-!include <C4/C4_Container>
-' C4_Deployment.puml is missing, simulate it with following definitions
-' Scope: A single software system.
-' Primary elements: Deployment nodes and containers within the software system in scope.
-' Intended audience: Technical people inside and outside of the software development team; including software architects, developers and operations/support staff.
-
-' Colors
-' ##################################
-!define NODE_FONT_COLOR    #444444
-!define NODE_BG_COLOR      #FFFFFF
-
-' Styling
-' ##################################
-
-skinparam rectangle<<node>> {
-  Shadowing false
-  StereotypeFontSize 0
-  FontColor NODE_FONT_COLOR
-  BackgroundColor NODE_BG_COLOR
-  BorderColor #444444
-}
-
-' Layout
-' ##################################
-
-!definelong LAYOUT_WITH_LEGEND
-hide stereotype
-legend right
-|=                    |= Type                |
-|<NODE_BG_COLOR>      | deployment node      |
-|<CONTAINER_BG_COLOR> | deployment container |
-endlegend
-!enddefinelong
-
-' Nodes
-' ##################################
-' PlantUML does not support automatic line breaks of container, if e_techn is very long insert line breaks with 
-' ""</size>\n<size:TECHN_FONT_SIZE>""
-!define Node(e_alias, e_label, e_techn) rectangle ""==e_label\n<size:TECHN_FONT_SIZE>[e_techn]</size>"" <<node>> as e_alias
+!include <C4/C4_Deployment>
 
 ' Structurizr.DeploymentView: deployment
 title Software System - Deployment - Default
-
-LAYOUT_WITH_LEGEND()
 
 Node(DatabaseServer__1edef6c, ""Database Server"", ""Ubuntu 12.04 LTS"") {
   Node(MySQL__1fa4f18, ""MySQL"", ""MySQL 5.5.x"") {
@@ -1173,6 +717,8 @@ Node(WebServer__1e2ffe, ""Web Server"", ""Ubuntu 12.04 LTS"") {
   }
 }
 Rel(SoftwareSystem__WebApplication1__31f1f25, SoftwareSystem__Database1__bb9c73, ""Reads from and writes to"", ""JDBC"")
+
+SHOW_LEGEND()
 @enduml
 
 ".UnifyNewLine().UnifyHashValues(), _stringWriter.ToString().UnifyHashValues());
@@ -1184,17 +730,15 @@ Rel(SoftwareSystem__WebApplication1__31f1f25, SoftwareSystem__Database1__bb9c73,
             PopulateWorkspace();
             DeploymentView deploymentView = _workspace.Views.DeploymentViews.First();
 
-            _plantUMLWriter.CustomBaseUrl = @"https://raw.githubusercontent.com/kirchsth/C4-PlantUML/master/";
+            _plantUMLWriter.CustomBaseUrl = @"https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/";
             _plantUMLWriter.Write(deploymentView, _stringWriter);
 
             Assert.Equal(
 @"@startuml
-!includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/master/C4_Deployment.puml
+!includeurl https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/C4_Deployment.puml
 
 ' Structurizr.DeploymentView: deployment
 title Software System - Deployment - Default
-
-LAYOUT_WITH_LEGEND()
 
 Node(DatabaseServer__1edef6c, ""Database Server"", ""Ubuntu 12.04 LTS"") {
   Node(MySQL__1fa4f18, ""MySQL"", ""MySQL 5.5.x"") {
@@ -1207,6 +751,8 @@ Node(WebServer__1e2ffe, ""Web Server"", ""Ubuntu 12.04 LTS"") {
   }
 }
 Rel(SoftwareSystem__WebApplication1__31f1f25, SoftwareSystem__Database1__bb9c73, ""Reads from and writes to"", ""JDBC"")
+
+SHOW_LEGEND()
 @enduml
 
 ".UnifyNewLine().UnifyHashValues(), _stringWriter.ToString().UnifyHashValues());

--- a/Structurizr.PlantUML.Tests/IO/PlantUML/PlantUMLWriterTests.cs
+++ b/Structurizr.PlantUML.Tests/IO/PlantUML/PlantUMLWriterTests.cs
@@ -101,7 +101,7 @@ actor ""User"" <<Person>> as 1
 @enduml
 
 @startuml
-title Software System - Deployment
+title Software System - Deployment - Default
 node ""Database Server"" <<Ubuntu 12.04 LTS>> as 23 {
   node ""MySQL"" <<MySQL 5.5.x>> as 24 {
     artifact ""Database"" <<Container>> as 25
@@ -254,7 +254,7 @@ actor ""User"" <<Person>> as 1
     
             Assert.Equal(
 @"@startuml
-title Software System - Deployment
+title Software System - Deployment - Default
 node ""Database Server"" <<Ubuntu 12.04 LTS>> as 23 {
   node ""MySQL"" <<MySQL 5.5.x>> as 24 {
     artifact ""Database"" <<Container>> as 25

--- a/Structurizr.PlantUML.Tests/Structurizr.PlantUML.Tests.csproj
+++ b/Structurizr.PlantUML.Tests/Structurizr.PlantUML.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/Structurizr.PlantUML/IO/C4PlantUML/C4PlantUmlException.cs
+++ b/Structurizr.PlantUML/IO/C4PlantUML/C4PlantUmlException.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Structurizr.PlantUML.IO.C4PlantUML
+{
+    public class C4PlantUmlException : Exception
+    {
+        public C4PlantUmlException(string message) : base(message) { }
+    }
+}

--- a/Structurizr.PlantUML/IO/C4PlantUML/C4PlantUmlWriter.cs
+++ b/Structurizr.PlantUML/IO/C4PlantUML/C4PlantUmlWriter.cs
@@ -25,10 +25,10 @@ namespace Structurizr.IO.C4PlantUML
         /// <summary>
         /// PlantUML-stdlib or https://raw.githubusercontent.com/RicardoNiepel/C4-PlantUML/release/1-0/ does not support
         /// dynamic or deployment diagrams. They can be used via the PlantUML-stdlib and in the diagram added definitions
-        /// or use a pull-request version which is available at https://raw.githubusercontent.com/kirchsth/C4-PlantUML/master/
+        /// or use a pull-request version which is available at https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/
         /// (if the value is empty/null then PlantUML-stdlib with added definitions is used)
         /// </summary>
-        public string CustomBaseUrl { get; set; } = ""; // @"https://raw.githubusercontent.com/kirchsth/C4-PlantUML/master/";
+        public string CustomBaseUrl { get; set; } = ""; // @"https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/";
 
         protected override void Write(SystemLandscapeView view, TextWriter writer)
         {
@@ -307,6 +307,9 @@ namespace Structurizr.IO.C4PlantUML
 
         protected override void WriteProlog(View view, TextWriter writer)
         {
+            if (view == null) throw new ArgumentNullException(nameof(view));
+            if (writer == null) throw new ArgumentNullException(nameof(writer));
+
             writer.WriteLine("@startuml");
 
             switch (view)
@@ -325,237 +328,15 @@ namespace Structurizr.IO.C4PlantUML
                     break;
 
                 case DynamicView _:
-                    if (!string.IsNullOrWhiteSpace(CustomBaseUrl))
-                    {
-                        writer.WriteLine($"!includeurl {CustomBaseUrl}C4_Dynamic.puml");
-                    }
-                    else
-                    {
-                        writer.WriteLine(@"!include <C4/C4_Component>");
-                        // Add missing deployment nodes (until they are part of the plantuml macros)
-                        writer.WriteLine(@"' C4_Dynamic.puml is missing, simulate it with following definitions");
-
-                        writer.WriteLine(@"' Scope: Interactions in an enterprise, software system or container.");
-                        writer.WriteLine(@"' Primary and supporting elements: Depends on the diagram scope - ");
-                        writer.WriteLine(@"'     enterprise - people and software systems related to the enterprise in scope ");
-                        writer.WriteLine(@"'     software system - see system context or container diagrams, ");
-                        writer.WriteLine(@"'     container - see component diagram.");
-                        writer.WriteLine(@"' Intended audience: Technical and non-technical people, inside and outside of the software development team.");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"' Dynamic diagram introduces (automatically) numbered interactions: ");
-                        writer.WriteLine(@"'     Interact(): used automatic calculated index, ");
-                        writer.WriteLine(@"'     Interact2(): index can be explicit defined,");
-                        writer.WriteLine(@"'     SetIndex(): set the next index, ");
-                        writer.WriteLine(@"'     GetIndex(): get the index and automatically increase index");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"' Index");
-                        writer.WriteLine(@"' ##################################");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!function $inc_($value, $step=1)");
-                        writer.WriteLine(@"  !return $value + $step");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!$index=1");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!function SetIndex($new_index)");
-                        writer.WriteLine(@"  !$index=$new_index");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!function GetIndex($auto_increase=1)");
-                        writer.WriteLine(@"  !$old = $index");
-                        writer.WriteLine(@"  !$index=$inc_($index, $auto_increase)");
-                        writer.WriteLine(@"  !return $old");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"' Interact");
-                        writer.WriteLine(@"' ##################################");
-                        writer.WriteLine(@"!define Interact2(e_index, e_from, e_to, e_label) Rel(e_from, e_to, ""e_index: e_label"")");
-                        writer.WriteLine(@"!define Interact2(e_index, e_from, e_to, e_label, e_techn) Rel(e_from, e_to, ""e_index: e_label"", e_techn)");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!define Interact2_Back(e_index, e_from, e_to, e_label) Rel_Back(e_from, e_to, ""e_index: e_label"")");
-                        writer.WriteLine(@"!define Interact2_Back(e_index, e_from, e_to, e_label, e_techn) Rel_Back(e_from, e_to, ""e_index: e_label"", e_techn)");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!define Interact2_Neighbor(e_index, e_from, e_to, e_label) Rel_Neighbor(e_from, e_to, ""e_index: e_label"")");
-                        writer.WriteLine(@"!define Interact2_Neighbor(e_index, e_from, e_to, e_label, e_techn) Rel_Neighbor(e_from, e_to, ""e_index: e_label"", e_techn)");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!define Interact2_Back_Neighbor(e_index, e_from, e_to, e_label) Rel_Back_Neighbor(e_from, e_to, ""e_index: e_label"")");
-                        writer.WriteLine(@"!define Interact2_Back_Neighbor(e_index, e_from, e_to, e_label, e_techn) Rel_Back_Neighbor(e_from, e_to, ""e_index: e_label"", e_techn)");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!define Interact2_D(e_index, e_from, e_to, e_label) Rel_D(e_from, e_to, ""e_index: e_label"")");
-                        writer.WriteLine(@"!define Interact2_D(e_index, e_from, e_to, e_label, e_techn) Rel_D(e_from, e_to, ""e_index: e_label"", e_techn)");
-                        writer.WriteLine(@"!define Interact2_Down(e_index, e_from, e_to, e_label) Rel_Down(e_from, e_to, ""e_index: e_label"")");
-                        writer.WriteLine(@"!define Interact2_Down(e_index, e_from, e_to, e_label, e_techn) Rel_Down(e_from, e_to, ""e_index: e_label"", e_techn)");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!define Interact2_U(e_index, e_from, e_to, e_label) Rel_U(e_from, e_to, ""e_index: e_label"")");
-                        writer.WriteLine(@"!define Interact2_U(e_index, e_from, e_to, e_label, e_techn) Rel_U(e_from, e_to, ""e_index: e_label"", e_techn)");
-                        writer.WriteLine(@"!define Interact2_Up(e_index, e_from, e_to, e_label) Rel_Up(e_from, e_to, ""e_index: e_label"")");
-                        writer.WriteLine(@"!define Interact2_Up(e_index, e_from, e_to, e_label, e_techn) Rel_Up(e_from, e_to, ""e_index: e_label"", e_techn)");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!define Interact2_L(e_index, e_from, e_to, e_label) Rel_L(e_from, e_to, ""e_index: e_label"")");
-                        writer.WriteLine(@"!define Interact2_L(e_index, e_from, e_to, e_label, e_techn) Rel_L(e_from, e_to, ""e_index: e_label"", e_techn)");
-                        writer.WriteLine(@"!define Interact2_Left(e_index, e_from, e_to, e_label) Rel_Left(e_from, e_to, ""e_index: e_label"")");
-                        writer.WriteLine(@"!define Interact2_Left(e_index, e_from, e_to, e_label, e_techn) Rel_Left(e_from, e_to, ""e_index: e_label"", e_techn)");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!define Interact2_R(e_index, e_from, e_to, e_label) Rel_R(e_from, e_to, ""e_index: e_label"")");
-                        writer.WriteLine(@"!define Interact2_R(e_index, e_from, e_to, e_label, e_techn) Rel_R(e_from, e_to, ""e_index: e_label"", e_techn)");
-                        writer.WriteLine(@"!define Interact2_Right(e_index, e_from, e_to, e_label) Rel_Right(e_from, e_to, ""e_index: e_label"")");
-                        writer.WriteLine(@"!define Interact2_Right(e_index, e_from, e_to, e_label, e_techn) Rel_Right(e_from, e_to, ""e_index: e_label"", e_techn)");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!unquoted function Interact($e_from, $e_to, $e_label) ");
-                        writer.WriteLine(@"  Interact2($index, ""$e_from"", ""$e_to"", ""$e_label"")");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"!unquoted function Interact($e_from, $e_to, $e_label, $e_techn) ");
-                        writer.WriteLine(@"  Interact2($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!unquoted function Interact_Back($e_from, $e_to, $e_label) ");
-                        writer.WriteLine(@"  Interact2_Back($index, ""$e_from"", ""$e_to"", ""$e_label"")");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"!unquoted function Interact_Back($e_from, $e_to, $e_label, $e_techn) ");
-                        writer.WriteLine(@"  Interact2_Back($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!unquoted function Interact_Neighbor($e_from, $e_to, $e_label) ");
-                        writer.WriteLine(@"  Interact2_Neighbor($index, ""$e_from"", ""$e_to"", ""$e_label"")");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"!unquoted function Interact_Neighbor($e_from, $e_to, $e_label, $e_techn) ");
-                        writer.WriteLine(@"  Interact2_Neighbor($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!unquoted function Interact_Back_Neighbor($e_from, $e_to, $e_label) ");
-                        writer.WriteLine(@"  Interact2_Back_Neighbor($index, ""$e_from"", ""$e_to"", ""$e_label"")");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"!unquoted function Interact_Back_Neighbor($e_from, $e_to, $e_label, $e_techn) ");
-                        writer.WriteLine(@"  Interact2_Back_Neighbor($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!unquoted function Interact_D($e_from, $e_to, $e_label) ");
-                        writer.WriteLine(@"  Interact2_D($index, ""$e_from"", ""$e_to"", ""$e_label"")");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"!unquoted function Interact_D($e_from, $e_to, $e_label, $e_techn) ");
-                        writer.WriteLine(@"  Interact2_D($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"!unquoted function Interact_Down($e_from, $e_to, $e_label) ");
-                        writer.WriteLine(@"  Interact2_Down($index, ""$e_from"", ""$e_to"", ""$e_label"")");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"!unquoted function Interact_Down($e_from, $e_to, $e_label, $e_techn) ");
-                        writer.WriteLine(@"  Interact2_Down($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!unquoted function Interact_U($e_from, $e_to, $e_label) ");
-                        writer.WriteLine(@"  Interact2_U($index, ""$e_from"", ""$e_to"", ""$e_label"")");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"!unquoted function Interact_U($e_from, $e_to, $e_label, $e_techn) ");
-                        writer.WriteLine(@"  Interact2_U($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"!unquoted function Interact_Up($e_from, $e_to, $e_label) ");
-                        writer.WriteLine(@"  Interact2_Up($index, ""$e_from"", ""$e_to"", ""$e_label"")");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"!unquoted function Interact_Up($e_from, $e_to, $e_label, $e_techn) ");
-                        writer.WriteLine(@"  Interact2_Up($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!unquoted function Interact_L($e_from, $e_to, $e_label) ");
-                        writer.WriteLine(@"  Interact2_L($index, ""$e_from"", ""$e_to"", ""$e_label"")");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"!unquoted function Interact_L($e_from, $e_to, $e_label, $e_techn) ");
-                        writer.WriteLine(@"  Interact2_L($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"!unquoted function Interact_Left($e_from, $e_to, $e_label) ");
-                        writer.WriteLine(@"  Interact2_Left($index, ""$e_from"", ""$e_to"", ""$e_label"")");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"!unquoted function Interact_Left($e_from, $e_to, $e_label, $e_techn) ");
-                        writer.WriteLine(@"  Interact2_Left($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!unquoted function Interact_R($e_from, $e_to, $e_label) ");
-                        writer.WriteLine(@"  Interact2_R($index, ""$e_from"", ""$e_to"", ""$e_label"")");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"!unquoted function Interact_R($e_from, $e_to, $e_label, $e_techn) ");
-                        writer.WriteLine(@"  Interact2_R($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"!unquoted function Interact_Right($e_from, $e_to, $e_label) ");
-                        writer.WriteLine(@"  Interact2_Right($index, ""$e_from"", ""$e_to"", ""$e_label"")");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                        writer.WriteLine(@"!unquoted function Interact_Right($e_from, $e_to, $e_label, $e_techn) ");
-                        writer.WriteLine(@"  Interact2_Right($index, ""$e_from"", ""$e_to"", ""$e_label"", $e_techn)");
-                        writer.WriteLine(@"  !$index=$inc_($index)");
-                        writer.WriteLine(@"!endfunction");
-                    }
+                    writer.WriteLine(!string.IsNullOrWhiteSpace(CustomBaseUrl)
+                        ? $"!includeurl {CustomBaseUrl}C4_Dynamic.puml"
+                        : $"!include <C4/C4_Dynamic>");
                     break;
 
                 case DeploymentView _:
-                    if (!string.IsNullOrWhiteSpace(CustomBaseUrl))
-                    {
-                        writer.WriteLine($"!includeurl {CustomBaseUrl}C4_Deployment.puml");
-                    }
-                    else
-                    {
-                        writer.WriteLine(@"!include <C4/C4_Container>");
-                        // Add missing deployment nodes (until they are part of the plantuml macros)
-                        writer.WriteLine(@"' C4_Deployment.puml is missing, simulate it with following definitions");
-
-                        writer.WriteLine(@"' Scope: A single software system.");
-                        writer.WriteLine(@"' Primary elements: Deployment nodes and containers within the software system in scope.");
-                        writer.WriteLine(@"' Intended audience: Technical people inside and outside of the software development team; including software architects, developers and operations/support staff.");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"' Colors");
-                        writer.WriteLine(@"' ##################################");
-                        writer.WriteLine(@"!define NODE_FONT_COLOR    #444444");
-                        writer.WriteLine(@"!define NODE_BG_COLOR      #FFFFFF");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"' Styling");
-                        writer.WriteLine(@"' ##################################");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"skinparam rectangle<<node>> {");
-                        writer.WriteLine(@"  Shadowing false");
-                        writer.WriteLine(@"  StereotypeFontSize 0");
-                        writer.WriteLine(@"  FontColor NODE_FONT_COLOR");
-                        writer.WriteLine(@"  BackgroundColor NODE_BG_COLOR");
-                        writer.WriteLine(@"  BorderColor #444444");
-                        writer.WriteLine(@"}");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"' Layout");
-                        writer.WriteLine(@"' ##################################");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"!definelong LAYOUT_WITH_LEGEND");
-                        writer.WriteLine(@"hide stereotype");
-                        writer.WriteLine(@"legend right");
-                        writer.WriteLine(@"|=                    |= Type                |");
-                        writer.WriteLine(@"|<NODE_BG_COLOR>      | deployment node      |");
-                        writer.WriteLine(@"|<CONTAINER_BG_COLOR> | deployment container |");
-                        writer.WriteLine(@"endlegend");
-                        writer.WriteLine(@"!enddefinelong");
-                        writer.WriteLine(@"");
-                        writer.WriteLine(@"' Nodes");
-                        writer.WriteLine(@"' ##################################");
-                        writer.WriteLine(@"' PlantUML does not support automatic line breaks of container, if e_techn is very long insert line breaks with ");
-                        writer.WriteLine(@"' ""</size>\n<size:TECHN_FONT_SIZE>""");
-                        writer.WriteLine(@"!define Node(e_alias, e_label, e_techn) rectangle ""==e_label\n<size:TECHN_FONT_SIZE>[e_techn]</size>"" <<node>> as e_alias");
-                    }
+                    writer.WriteLine(!string.IsNullOrWhiteSpace(CustomBaseUrl)
+                        ? $"!includeurl {CustomBaseUrl}C4_Deployment.puml"
+                        : $"!include <C4/C4_Deployment>");
                     break;
 
                 default:
@@ -570,8 +351,6 @@ namespace Structurizr.IO.C4PlantUML
             writer.WriteLine("title " + GetTitle(view));
             writer.WriteLine();
 
-            if (LayoutWithLegend)
-                writer.WriteLine("LAYOUT_WITH_LEGEND()");  // C4 PlantUML workaround add ()
             if (LayoutAsSketch)
                 writer.WriteLine("LAYOUT_AS_SKETCH()");  // C4 PlantUML workaround add ()
             if (Layout.HasValue)
@@ -588,8 +367,23 @@ namespace Structurizr.IO.C4PlantUML
                         throw new InvalidOperationException($"Unknown {nameof(LayoutDirection)} value");
                 }
             }
-            if (LayoutWithLegend || LayoutAsSketch || Layout.HasValue)
+            if (LayoutAsSketch || Layout.HasValue)
                 writer.WriteLine();
+        }
+
+        protected virtual void WriteEpilog(View view, TextWriter writer)
+        {
+            if (view == null) throw new ArgumentNullException(nameof(view));
+            if (writer == null) throw new ArgumentNullException(nameof(writer));
+
+            if (LayoutWithLegend)
+            {
+                writer.WriteLine();
+                writer.WriteLine("SHOW_LEGEND()");  // C4 PlantUML workaround add ()
+            }
+
+            writer.WriteLine("@enduml");
+            writer.WriteLine("");
         }
 
         protected virtual void Write(Element element, TextWriter writer, int indentLevel = 0, bool asBoundary = false)
@@ -617,10 +411,6 @@ namespace Structurizr.IO.C4PlantUML
                         macro = "Node";
                         title = deploymentNode.Name + (deploymentNode.Instances > 1 ? $" (x{deploymentNode.Instances})" : "");
                         technology = deploymentNode.Technology;
-                        // PlantUML supports no automatic line breaks of titles, if it belongs to a surrounding object
-                        // make workaround with html tags (they are not working via multiple lines too)
-                        if (technology.Length > 30)
-                            technology = BlockText(technology, 30, @"</size>\n<size:TECHN_FONT_SIZE>");
                         break;
                     default:
                         throw new NotSupportedException($"{element.GetType()} not supported boundary type");
@@ -730,7 +520,7 @@ namespace Structurizr.IO.C4PlantUML
                 tech = !string.IsNullOrWhiteSpace(relationship.Technology) ? relationship.Technology : null;
 
             var macro = GetSpecificLayoutMacro(relationshipView);
-            macro = "Interact2" + macro.Substring("Rel".Length);
+            macro = "RelIndex" + macro.Substring("Rel".Length);
 
             writer.Write($"{macro}(\"{order}\", {source}, {dest}, \"{EscapeText(label)}\"");
             if (tech != null)

--- a/Structurizr.PlantUML/IO/C4PlantUML/ModelExtensions/ModelExtensions.cs
+++ b/Structurizr.PlantUML/IO/C4PlantUML/ModelExtensions/ModelExtensions.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Linq;
+
+namespace Structurizr.IO.C4PlantUML.ModelExtensions
+{
+    public static class ModelExtensions
+    {
+        /// <summary>
+        /// new impl. of CanonicalName starts with "{ElementType}://" or "{ElementType}://{DeploymentName}/{DeploymentName}/"   instead of "/" therefore it can be optionally ignored
+        /// Additional / in staticNames have to be converted to .
+        /// </summary>
+        /// <param name="canonicalName">the canonical name with elementType prefix (e.g. Container://SoftwareSystem/Container) or without elementType prefix (e.g. /SoftwareSystem/Container)</param>
+        /// <returns></returns>
+        public static Element GetElementWithCanonicalOrStaticalName(this Model model, string canonicalName, bool compareOnlyLastPart=true)
+        {
+            if (string.IsNullOrWhiteSpace(canonicalName))
+                throw new ArgumentException("A canonical name must be specified.");
+            var found = model.GetElements().FirstOrDefault<Element>((Func<Element, bool>) (x =>
+            {
+                if (compareOnlyLastPart)
+                    return x.CanonicalName.EndsWith(canonicalName);
+                else
+                    return x.CanonicalName == canonicalName;
+            }));
+
+            if (found == null)
+            {
+                var all = model.GetElements().Select(e => e.CanonicalName).ToList();
+                var combined = string.Join("\n", all);
+                combined = combined;
+            }
+
+            return found;
+        }
+    }
+}

--- a/Structurizr.PlantUML/IO/C4PlantUML/ModelExtensions/ModelExtensions.cs
+++ b/Structurizr.PlantUML/IO/C4PlantUML/ModelExtensions/ModelExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Structurizr.PlantUML.IO.C4PlantUML;
 
 namespace Structurizr.IO.C4PlantUML.ModelExtensions
 {
@@ -27,9 +28,9 @@ namespace Structurizr.IO.C4PlantUML.ModelExtensions
             {
                 var all = model.GetElements().Select(e => e.CanonicalName).ToList();
                 var combined = string.Join("\n", all);
-                combined = combined;
+                throw new C4PlantUmlException(
+                    $"Element {canonicalName} could not be found. Following elements exist:\n{combined}");
             }
-
             return found;
         }
     }

--- a/Structurizr.PlantUML/IO/C4PlantUML/ModelExtensions/RelationshipViewExtensions.cs
+++ b/Structurizr.PlantUML/IO/C4PlantUML/ModelExtensions/RelationshipViewExtensions.cs
@@ -1,9 +1,15 @@
+using System.Collections.Generic;
+
 namespace Structurizr.IO.C4PlantUML.ModelExtensions
 {
+    /// <summary>
+    /// WORKAROUND: RelationshipView supports no properties anymore, therefore the direction is stored in Position
+    /// </summary>
     public static class RelationshipViewExtensions
     {
         /// <summary>
         /// Get a direction of the relation which should be used in a specific C4PlantUML views
+        /// (direction is stored in Position)
         /// </summary>
         /// <param name="relationshipView"></param>
         /// <param name="viewSpecific">returns true if it is defined via the view specific RelationshipView and false if it is defined via the underlying Relationship</param>
@@ -11,7 +17,7 @@ namespace Structurizr.IO.C4PlantUML.ModelExtensions
         public static string GetDirection(this RelationshipView relationshipView, out bool viewSpecific)
         {
             string value = DirectionValues.NotSet;
-            if (relationshipView.Properties?.TryGetValue(Properties.Direction, out value) == true)
+            if (relationshipView.Position.HasValue && Position2Direction.TryGetValue(relationshipView.Position.Value, out value) == true)
             {
                 viewSpecific = true;
                 return value;
@@ -24,15 +30,32 @@ namespace Structurizr.IO.C4PlantUML.ModelExtensions
 
         /// <summary>
         /// Set a direction of the relation which should be used in a specific C4PlantUML views
+        /// (direction is internal stored in Position)
         /// </summary>
         /// <param name="relationshipView"></param>
         /// <param name="direction">one of <see cref="DirectionValues"/></param>
         public static void SetDirection(this RelationshipView relationshipView, string direction)
         {
             if (string.IsNullOrWhiteSpace(direction)) // direction DirectionValues.NotSet
-                relationshipView.Properties.Remove(Properties.Direction);
+                relationshipView.Position = null;
             else
-                relationshipView.Properties[Properties.Direction] = direction;
+                relationshipView.Position = Direction2Position[direction];
         }
+
+        private static Dictionary<string, int> Direction2Position = new Dictionary<string, int>
+        {
+            [DirectionValues.Up] = 1,
+            [DirectionValues.Down] = 2,
+            [DirectionValues.Left] = 3,
+            [DirectionValues.Right] = 4
+        };
+
+        private static Dictionary<int, string> Position2Direction = new Dictionary<int, string>
+        {
+            [1] = DirectionValues.Up,
+            [2] = DirectionValues.Down,
+            [3] = DirectionValues.Left,
+            [4] = DirectionValues.Right
+        };
     }
 }

--- a/Structurizr.PlantUML/IO/C4PlantUML/PlantUMLWriterBase.cs
+++ b/Structurizr.PlantUML/IO/C4PlantUML/PlantUMLWriterBase.cs
@@ -165,13 +165,20 @@ namespace Structurizr.IO.C4PlantUML
         {
             if (String.IsNullOrWhiteSpace(s)) return "";
 
-            s = s
-                .Trim('/')
-                .Replace(" ", "")
-                .Replace("-", "")
-                .Replace("[", "")
-                .Replace("]", "")
-                .Replace("/", "__");
+            // canonically name calculation changed
+            // a) instead of "/" starts with "{ElementType}://"; remove it that it is compatible with old impl.
+            // b) deployment namespaces are added with "/"; remove it that it is shorter (unique parts created via hash)
+            // c) orig "/" in static namespaces replaced with "."; replace with "__" that it is compatible with old impl.
+            var p = s.LastIndexOf('/');
+            if (p >= 0)
+                s = s.Substring(p + 1);
+
+            s = s.Replace(" ", "")
+                 .Replace("-", "")
+                 .Replace("[", "")
+                 .Replace("]", "")
+                 .Replace(".", "__");
+
             if (hash.HasValue)
             {
                 s = s + "__" + hash.Value.ToString("x");

--- a/Structurizr.PlantUML/IO/C4PlantUML/PlantUMLWriterBase.cs
+++ b/Structurizr.PlantUML/IO/C4PlantUML/PlantUMLWriterBase.cs
@@ -198,45 +198,6 @@ namespace Structurizr.IO.C4PlantUML
                 ? String.IsNullOrWhiteSpace(view.Title) ? view.Name : view.Title
                 : throw new ArgumentNullException(nameof(view));
 
-        protected string BlockText(string s, int blockWidth, string formattedLineBreak)
-        {
-            var block = s;
-
-            if (blockWidth > 0 && !s.Contains("\n") && !s.Contains("\r"))
-            {
-                var formatted = new StringBuilder();
-                int pos = 0;
-                string word = "";
-
-                foreach (var c in s)
-                {
-                    word += c;
-                    if (c == ' ')
-                    {
-                        if (pos != 0 && pos + word.Length > blockWidth)
-                        {
-                            formatted.Append(formattedLineBreak);
-                            pos = 0;
-                        }
-                        formatted.Append(word);
-                        pos += word.Length;
-                        word = "";
-                    }
-                }
-
-                if (word.Length > 0)
-                {
-                    if (pos != 0 && pos + word.Length > blockWidth)
-                        formatted.Append(formattedLineBreak);
-                    formatted.Append(word);
-                }
-
-                block = formatted.ToString();
-            }
-
-            return block;
-        }
-
         protected string EscapeText(string s) => s.Replace("\"", "&quot;");
     }
 }

--- a/Structurizr.PlantUML/Structurizr.PlantUML.csproj
+++ b/Structurizr.PlantUML/Structurizr.PlantUML.csproj
@@ -16,11 +16,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Structurizr.Core" Version="0.9.6" />
+    <PackageReference Include="Structurizr.Core" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Structurizr.Reflection.Examples/Structurizr.Reflection.Examples.csproj
+++ b/Structurizr.Reflection.Examples/Structurizr.Reflection.Examples.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Structurizr.Client" Version="0.9.3" />
+    <PackageReference Include="Structurizr.Client" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Structurizr.Annotations\Structurizr.Annotations.csproj" />

--- a/Structurizr.Reflection/Structurizr.Reflection.csproj
+++ b/Structurizr.Reflection/Structurizr.Reflection.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Structurizr.Core" Version="0.9.6" />
+    <PackageReference Include="Structurizr.Core" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Structurizr.Reflection/Structurizr.Reflection.csproj
+++ b/Structurizr.Reflection/Structurizr.Reflection.csproj
@@ -24,10 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="System.Runtime" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Structurizr.Analysis\Structurizr.Analysis.csproj" />
     <ProjectReference Include="..\Structurizr.Annotations\Structurizr.Annotations.csproj" />
   </ItemGroup>

--- a/docs/c4-plantuml.md
+++ b/docs/c4-plantuml.md
@@ -10,7 +10,7 @@ Structurizr for .NET also includes a simple exporter that can create diagram def
 - Deployment*
 
 *..Dynamic and Deployment diagrams are part of an open pull request (from https://github.com/kirchsth/C4-PlantUML). The diagrams can use the definitions via 
-CustomBaseUrl=https://raw.githubusercontent.com/kirchsth/C4-PlantUML/master/ or if it is not set then the definition is merged in each diagram)
+CustomBaseUrl=https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended/ or if it is not set then the definition is merged in each diagram)
 
 Simply create your software architecture model and views as usual, and use the [C4PlantUMLWriter](../Structurizr.PlantUML/IO/C4PlantUML/C4PlantUMLWriter.cs) class to export the views. [For example](../Structurizr.Examples/C4PlantUML.cs):
 


### PR DESCRIPTION
- Update from netcoreapp 1.1 to netcoreapp 2.1
- Update from netstandard 1.3 to netstandard 2.0
- Structurizr.Reflection - remove obsolete System.Runtime reference

- Structurizr.AdrTools: link use  "%2F" instead of "/" (sync with java impl.)

- C4PlantUML:
  - Updated that it works with new calculated CanonicalName
    new GetElementWithCanonicalOrStaticalName() is added it throws an Exception(with all valid canonical names) if element not found
  - Test updated with new sample
  - RelationshipView stores "DirectionValues" in Position (properties are not available anymore)

  -  update generated source to new C4PlantUml stdlib v2.2.0
    - all obsolete "C4_Dynamic" and "C4_Deployment" calls are removed
    - new SHOW_LEGEND() call is used (instead of LAYOUT_WITH_LEGEND)
    - new RelIndex() call is used (instead of Interact2)
    - new kirchsth extsions are stored in https://raw.githubusercontent.com/kirchsth/C4-PlantUML/extended (not master anymore)
    - new stdlib Node()-impl supports automatic line breaks (BlockText calculation is obsolete, no </size>\n<size:TECHN_FONT_SIZE>)

(new C4PlantUml stdlib v2.2.0 will be added in a separate PR)
